### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -125,7 +125,7 @@ secrets/
 .secrets/
 
 flash_fpga.py
-requirements-test.txt
+#requirements-test.txt
 .github/
 .pytest_cache/
 .benchmarks/


### PR DESCRIPTION
The file requirements-test.txt was listed in .dockerignore, causing it to be excluded from the  build context. As a result, the COPY ./requirements-test.txt /build/ step in the Containerfile fails because the file is missing, breaking the build process.