### PR TITLE
Create active_device_nvme.yaml

### DIFF
--- a/configs/devices/active_device_nvme.yaml
+++ b/configs/devices/active_device_nvme.yaml
@@ -1,0 +1,61 @@
+name: active_device_nvme
+device_type: nvme
+device_class: storage
+
+identification:
+  vendor_id: 0x144D    # Samsung
+  device_id: 0xA808    # 980 Pro NVMe SSD
+  class_code: 0x010802
+  revision_id: 0x01
+
+registers:
+  command: 0x0406
+  status: 0x0290
+  revision_id: 0x02
+  cache_line_size: 0x10
+  latency_timer: 0x20
+  header_type: 0x00
+  bist: 0x00
+
+capabilities:
+  max_payload_size: 512
+  msi_vectors: 8
+  msix_vectors: 0
+  supports_msi: true
+  supports_msix: false
+  supports_power_management: true
+  supports_advanced_error_reporting: true
+  link_width: 4
+  link_speed: "8.0GT/s"
+
+  active_device:
+    enabled: true
+    timer_period: 50000
+    timer_enable: true
+    interrupt_mode: "msi"
+    interrupt_vector: 0
+    priority: 10
+    msi_vector_width: 3        # 8 vectors
+    msi_64bit_addr: true
+    num_interrupt_sources: 8
+    default_source_priority: 8
+
+    num_sources: 8
+    vendor_id: "16'h144D"
+    device_id: "16'hA808"
+    completer_id: "16'h0100"
+    default_priority: 8
+
+    num_msix: 0
+    msix_table_bir: 0
+    msix_table_offset: 0
+    msix_pba_bir: 0
+    msix_pba_offset: 0
+
+custom_properties:
+  storage_specific:
+    namespace_size: 1TB
+    support_smart: true
+    support_ana: true
+    temperature_sensor: true
+    firmware_version: "4B2QEXM7"


### PR DESCRIPTION
Use case: Simulated NVMe device with interrupt sources for admin and I/O queues, SMART telemetry, and realistic performance parameters.