### PR TITLE
Potential fix for code scanning alert no. 32: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
   publish-github:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/ramseymcgrath/PCILeechFWGenerator/security/code-scanning/32](https://github.com/ramseymcgrath/PCILeechFWGenerator/security/code-scanning/32)

To fix the problem, we should explicitly set a minimal `permissions` block in the `publish-github` job to restrict the GITHUB_TOKEN to only the permissions required. Since the job creates GitHub releases (writes to repository contents and releases), it needs at least `contents: write`. If it only needs to read from contents and write releases, then `contents: write` is a good starting point. Add the following block under the `publish-github` job, at the same indentation as `runs-on`, before `steps`:

```yaml
permissions:
  contents: write
```

This will ensure the job only has permission to write repository contents (which is necessary to create releases), and will not have other unnecessary permissions. No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
