### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ramseymcgrath/PCILeechFWGenerator/security/code-scanning/31](https://github.com/ramseymcgrath/PCILeechFWGenerator/security/code-scanning/31)

To fix this issue, we should add a `permissions` block at the root of the workflow (applies to all jobs unless overridden) and include only the necessary permissions. Based on the provided workflow, the primary operations include checking out the repository (`contents: read`), uploading coverage reports (`contents: read`), and using secrets for Codecov (`contents: read`). None of the jobs appear to require write access to the repository. Therefore, the permissions can be set to `contents: read` at the workflow level to adhere to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
