### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,14 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/ramseymcgrath/PCILeechFWGenerator/security/code-scanning/28](https://github.com/ramseymcgrath/PCILeechFWGenerator/security/code-scanning/28)

To fix this issue, add a `permissions` block at the root level of the workflow file to set the default permissions for all jobs, and specify `permissions: contents: read` for the `build` job to ensure it adheres to the principle of least privilege. This will restrict the permissions of the `GITHUB_TOKEN` to read-only access for repository contents unless otherwise specified for individual jobs (`pypi-publish` and `publish-github` already have custom permissions defined).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
