### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/datadog.yml
+++ b/.github/workflows/datadog.yml
@@ -1,6 +1,8 @@
 on: [push]
 
 name: Datadog Software Composition Analysis
+permissions:
+  contents: read
 
 jobs:
   software-composition-analysis:


### PR DESCRIPTION
Potential fix for [https://github.com/ramseymcgrath/PCILeechFWGenerator/security/code-scanning/27](https://github.com/ramseymcgrath/PCILeechFWGenerator/security/code-scanning/27)

To fix the problem, add an explicit `permissions` block to the workflow. This block should specify only the required permissions for the actions in the workflow to function correctly. At the root level of the workflow, the `permissions` block will apply to all jobs unless overridden within specific jobs. For this workflow, setting `contents: read` should suffice because the actions only need to check out the repository and perform analyses, which require no write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
