### PR TITLE
Fix VFIO diagnostics Check class initialization error

### DIFF
--- a/src/cli/vfio_diagnostics.py
+++ b/src/cli/vfio_diagnostics.py
@@ -206,7 +206,7 @@ class Check:
     message: str
     remediation: Optional[str] = None
     commands: Optional[List[str]] = None
-
+    prefix: Optional[str] = None
 
 @dataclass
 class Report:


### PR DESCRIPTION
The VFIO diagnostics functionality was failing with the following error when running:

sudo python3 pcileech.py check --device 0000:03:00.0 --interactive

Error message: 

Check.__init__() got an unexpected keyword argument 'prefix'

The Check dataclass in src/cli/vfio_diagnostics.py was missing the prefix parameter in its field definition. When the diagnostics engine tried to initialize a Check object with a prefix argument, it failed because the dataclass didn't accept this parameter. so i added the missing prefix field to the Check dataclass as an optional parameter with a default value of None.