### PR TITLE
Potential fix for code scanning alert no. 252: Unhashable object hashed

### DIFF
--- a/src/utils/attribute_access.py
+++ b/src/utils/attribute_access.py
@@ -8,6 +8,7 @@ the codebase.
 """
 
 from typing import Any, Optional, TypeVar, Union, cast
+import collections.abc
 
 T = TypeVar("T")
 
@@ -189,6 +190,8 @@ def get_multiple_attrs(
     result = {}
 
     for attr_name in attr_names:
+        if not isinstance(attr_name, collections.abc.Hashable):
+            raise TypeError(f"Attribute name {attr_name!r} is unhashable and cannot be used as a dict key.")
         default_value = defaults.get(attr_name, None)
         result[attr_name] = safe_get_attr(obj, attr_name, default_value)
 


### PR DESCRIPTION
Potential fix for [https://github.com/VoltCyclone/PCILeechFWGenerator/security/code-scanning/252](https://github.com/VoltCyclone/PCILeechFWGenerator/security/code-scanning/252)

To fix the problem, we need to ensure that only hashable objects are used as keys in the dictionary `result`. The best way to do this, while maintaining the existing functionality, is to check—inside the loop—whether each `attr_name` is hashable before using it as a dict key. If an unhashable object is encountered, we should raise a `TypeError` or `ValueError` with a helpful message. This prevents obscure errors later and helps the user find their mistake promptly. We will add a check using the `collections.abc.Hashable` abstract base class to test if `attr_name` is hashable. This entails importing `collections.abc` and inserting an `if not isinstance(attr_name, collections.abc.Hashable)` check inside the loop in `get_multiple_attrs`. The rest of the function remains unchanged.

- Edit only `src/utils/attribute_access.py`.
- Add `import collections.abc` near the top (after current imports).
- In `get_multiple_attrs`, inside the loop over `attr_names`, before using `attr_name` as a key, check if it's hashable, and raise an error if it is not.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
