### PR TITLE
Fix MSIXData _asdict AttributeError in v0.14.0-beta.16

### DIFF
--- a/src/cli/host_device_collector.py
+++ b/src/cli/host_device_collector.py
@@ -9,6 +9,7 @@ for VFIO operations inside the container.
 import json
 import logging
 import time
+from dataclasses import asdict
 
 from pathlib import Path
 from typing import Dict, Any, Optional
@@ -111,7 +112,7 @@ class HostDeviceCollector:
                     "config_space_hex": config_space_bytes.hex(),
                     "device_info": device_info,
                     "msix_data": (
-                        msix_data._asdict() if msix_data.preloaded else None
+                        asdict(msix_data) if msix_data.preloaded else None
                     ),
                     "collection_metadata": {
                         "collected_at": time.time(),


### PR DESCRIPTION
## Description

Fixes the `AttributeError: 'MSIXData' object has no attribute '_asdict'` error reported in issue #458.

## Root Cause

The bug was caused by trying to call `_asdict()` method on a `MSIXData` object, which is defined as a `@dataclass` (not a `namedtuple`). The `_asdict()` method only exists on `namedtuple` objects, but dataclasses don't have this method.

**Location of the bug:**
- File: `src/cli/host_device_collector.py`
- Line: 102
- Code: `msix_data._asdict() if msix_data.preloaded else None`

## Solution

Replaced the incorrect `msix_data._asdict()` call with the proper `dataclasses.asdict(msix_data)` function, which is the correct way to convert a dataclass to a dictionary.

## Changes Made

1. **Added import**: `from dataclasses import asdict`
2. **Fixed the method call**: Changed `msix_data._asdict()` to `asdict(msix_data)`

## Testing

This fix resolves the AttributeError and allows the MSI-X capability data to be properly serialized when `msix_data.preloaded` is `True`.

## Background

This is a common Python compatibility issue when mixing dataclasses and namedtuples. The `_asdict()` method is specific to namedtuples, while dataclasses require the `dataclasses.asdict()` function for dictionary conversion.

Fixes #458