### PR TITLE
Fix for Wrong number of arguments in a call

### DIFF
--- a/src/behavioral/base.py
+++ b/src/behavioral/base.py
@@ -126,6 +126,6 @@ class BehavioralSpec:
 def require(condition: bool, message: str, **context) -> None:
     """Validate condition or exit with error."""
     if not condition:
-        log_error_safe(safe_format("Build aborted: {msg} | ctx={ctx}", 
+        log_error_safe(logger, safe_format("Build aborted: {msg} | ctx={ctx}", 
                                   msg=message, ctx=context))
         raise SystemExit(2)


### PR DESCRIPTION
To fix this problem, ensure that the call to `log_error_safe` at line 129 includes the required `logger` argument as its first parameter, followed by the formatted message. The correct pattern, as shown elsewhere in this file, is to use `log_error_safe(logger, safe_format(...))`. In this location, the original code omits the `logger`, so the second argument should be the output of `safe_format("Build aborted: {msg} | ctx={ctx}", msg=message, ctx=context)`. No additional imports or method definitions are required, and only line 129 of `src/behavioral/base.py` needs to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._