### PR TITLE
fix: donor IDs in FIFO + IP CONFIG; unblock 75t484_x1 synthesis (#593)

### DIFF
--- a/docs/plans/issue-593-xilinx-defaults-fifo.md
+++ b/docs/plans/issue-593-xilinx-defaults-fifo.md
@@ -1,0 +1,140 @@
+# Issue #593 — Donor IDs not reaching FIFO; 75t484_x1 synthesis broken
+
+Branch: `fix/issue-593-xilinx-defaults-fifo`
+Goal: fix the two related symptoms reported in [#593](https://github.com/VoltCyclone/PCILeechFWGenerator/issues/593) — donor vendor/device/subsys/rev IDs reaching the upstream `pcileech_fifo.sv` runtime register file, and the 75t484_x1 board synthesizing cleanly.
+
+## Background
+
+The user reports two failures driven by the same underlying gap:
+
+1. **Symptom A — board `75t` (EnigmaX1):** build succeeds, but the generated `pcileech_fifo.sv` still contains Xilinx defaults (`16'h10EE` vendor, `16'h0666` device, `8'h02` rev) at its `_pcie_core_config` reset and at the `rw[143:128]…rw[199:192]` reset block. Donor IDs land in `pcileech_cfgspace.coe` (BRAM) but never in the FIFO's runtime control register.
+2. **Symptom B — board `pcileech_75t484_x1` (CaptainDMA/75t484_x1):** synthesis fails with `cannot resolve hierarchical name for the item 'pcie_cfg_subsys_vend_id'` at `pcileech_fifo.sv:311`, plus follow-on "part-select width could not be resolved to a constant" and `failed synthesizing module 'pcileech_fifo'` / `pcileech_75t484_x1_top`. Root cause: the upstream 75t484_x1 `pcileech_fifo.sv` writes to `dpcie.pcie_cfg_subsys_vend_id`, `pcie_cfg_subsys_id`, `pcie_cfg_vend_id`, `pcie_cfg_dev_id`, `pcie_cfg_rev_id` (lines 311–315), but the matching `pcileech_header.svh` `IfPCIeFifoCore` interface (lines 244–265) declares only `pcie_rst_core`, `pcie_rst_subsys`, and DRP signals. The fifo references interface members that do not exist — an upstream submodule self-inconsistency.
+
+`pcie_cfg_subsys_vend_id` is grepped only in `lib/voltcyclone-fpga/`; our generator never emits it. `lib/voltcyclone-fpga` is a git submodule (`VoltCyclone/voltcyclone-fpga`), so any patch to its files belongs upstream **or** must be applied as a generation-time post-processing step on the staged copies in `pcileech_datastore/output/<board>/src/`. Direct modification of `lib/voltcyclone-fpga/...` will be wiped by the next submodule update and is out of scope here.
+
+The donor-ID flow currently only injects values into `pcileech_cfgspace.coe.j2` (via `src/templating/sv_overlay_generator.py:57-124`). There is no Vivado IP `set_property CONFIG.Vendor_ID/Device_ID/...` step (grep finds these strings only under `tests/`) and no patch step on `pcileech_fifo.sv`. Both gaps need closing.
+
+Source-file copy lives in `src/vivado_handling/pcileech_build_integration.py:207-286` (`_copy_source_files`) via `TemplateDiscovery.get_source_files(board_name)` (`src/file_management/template_discovery.py:228-269`). Insert any post-copy patching there.
+
+## Conventions
+
+- One commit per task. Conventional-commit prefix: `fix(build): ...` or `fix(template): ...` matching the area.
+- Every task ships with a regression test under `tests/`. New tests should sit beside the closest existing siblings.
+- Run `pytest tests/<area> -x` plus the task-specific subset before declaring done. Full repo suite is not required for a green light, but CI must pass before merge.
+- Do **not** modify files under `lib/voltcyclone-fpga/` — those changes will be lost on submodule update. Patch staged outputs instead.
+- Do **not** rework the donor-injection pipeline beyond what these tasks need. The cfgspace-overlay path stays as-is unless a task explicitly says otherwise.
+- No drive-by board-config changes. If another board has a similar interface mismatch, leave a `# TODO(issue-593-followup):` and surface it in the commit body.
+
+## Tasks
+
+### T1 — Patch staged FIFO sources to inject donor IDs into the RW reset block (Symptom A)
+
+**File to edit:** `src/vivado_handling/pcileech_build_integration.py` (or a new `src/vivado_handling/fifo_donor_patcher.py` invoked from there). Pick the new module if the patcher exceeds ~40 lines.
+
+**Bug:** `_copy_source_files` copies `pcileech_fifo.sv` verbatim from `lib/voltcyclone-fpga/<board>/src/` to the staged output. Donor IDs are never written into the FIFO's reset values. The host therefore sees the upstream Xilinx defaults until/unless software writes to the RW register at runtime — which the PCILeech runtime does not currently do for these fields (the upstream comments mark them `(NOT IMPLEMENTED)`).
+
+**Fix:** after copying `pcileech_fifo.sv` into the per-board output directory, run a deterministic textual rewrite that replaces the four hardcoded ID literals in the RW reset block with the donor's values. Anchor on the upstream comments to avoid false matches:
+
+| Line tag (upstream) | Field | Replace with |
+|---|---|---|
+| `// +010: CFG_SUBSYS_VEND_ID` | `rw[143:128] <= 16'h10EE;` | `16'h<donor.subsys_vendor_id>` |
+| `// +012: CFG_SUBSYS_ID`      | `rw[159:144] <= 16'h0007;` | `16'h<donor.subsys_id>` |
+| `// +014: CFG_VEND_ID`        | `rw[175:160] <= 16'h10EE;` | `16'h<donor.vendor_id>` |
+| `// +016: CFG_DEV_ID`         | `rw[191:176] <= 16'h0666;` | `16'h<donor.device_id>` |
+| `// +018: CFG_REV_ID`         | `rw[199:192] <= 8'h02;`    | `8'h<donor.revision_id>` |
+
+Also rewrite the `_pcie_core_config` packed initializer on line ~216 (`reg [79:0] _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };`) using the same donor values, preserving the leading control bits. Build the literal from the donor dict and substitute the whole RHS.
+
+Use regex with the comment as anchor (e.g. `r"rw\[143:128\]\s*<=\s*16'h[0-9A-Fa-f]{4};\s*//\s*\+010: CFG_SUBSYS_VEND_ID"`) so a future upstream edit that changes the hex value still matches. If any anchor fails to match, raise — do **not** silently skip. The build is broken if we can't patch.
+
+Take donor IDs from the same source `sv_overlay_generator.generate_config_space_overlay` already consumes (the `device_config` / `config_space` dict). Pass it through from the build integration entry point.
+
+**Acceptance:**
+- New test `tests/vivado_handling/test_fifo_donor_patcher.py` with: a synthetic upstream `pcileech_fifo.sv` containing the five anchor lines and the `_pcie_core_config` initializer; a donor dict (`{vendor_id: 0x8086, device_id: 0x1533, subsys_vendor_id: 0x8086, subsys_id: 0x0001, revision_id: 0x03}`); assert all five lines and the initializer come out with the donor values and untouched anchor comments.
+- Negative test: missing one anchor → patcher raises (chosen exception type, message names the missing anchor).
+- Integration-style test that runs `_copy_source_files` against a fixture board dir, points it at a temp output, and greps the output `pcileech_fifo.sv` for the donor literal.
+- Manual: regenerate firmware for a 75t board against any donor; confirm the staged `pcileech_fifo.sv` no longer contains `16'h10EE` or `16'h0666` (unless the donor IS Xilinx).
+
+### T2 — Emit Vivado IP `CONFIG.Vendor_ID` / `Device_ID` / `Subsystem_*` / `Revision_ID` (Symptom A, hardware-visible)
+
+**File to edit:** `src/templating/tcl_builder.py` (and whichever template emits `02_ip_config.tcl` — find via `grep -n "02_ip_config" src/`).
+
+**Bug:** the PCIe 7-series IP block is what the host reads during enumeration. The generator never overrides its `CONFIG.Vendor_ID`/`Device_ID`/`Subsystem_Vendor_Id`/`Subsystem_Id`/`Revision_ID`, so even with the cfgspace shadow correctly populated, the IP itself reports Xilinx defaults during link bring-up and BAR enumeration on some flows. `grep -rn "CONFIG\.Device_ID" src/ tests/` returns hits only under `tests/`, confirming no production code path emits these.
+
+**Fix:** in the IP-config TCL stage, add `set_property -dict [list CONFIG.Vendor_ID 0x<vid> CONFIG.Device_ID 0x<did> CONFIG.Subsystem_Vendor_Id 0x<svid> CONFIG.Subsystem_Id 0x<ssid> CONFIG.Revision_ID 0x<rev>] [get_ips <pcie_ip_name>]` after the existing IP creation. The IP name varies by board (`pcie_7x_0` for most A7 boards) — surface it from the existing board config rather than hardcoding.
+
+If the IP-config TCL is not currently templated (i.e. it's a static file under `lib/voltcyclone-fpga/<board>/`), add a generation-time appendage written to a separate TCL fragment that the master script sources after the upstream IP-config step. Do not modify the vendored TCL in place.
+
+**Acceptance:**
+- Unit test that calls the TCL builder with a donor dict and asserts the rendered TCL contains the five `CONFIG.*` properties with the correct hex values.
+- Test that asserts the generated TCL still parses (basic balanced-bracket / `set_property` syntax check is enough — full TCL eval is overkill).
+- Manual: open the generated `02_ip_config.tcl` (or appended fragment), grep for `CONFIG.Vendor_ID`, confirm donor value.
+
+### T3 — Make 75t484_x1 synthesize: drop fifo writes to undeclared interface fields (Symptom B)
+
+**File to edit:** the same patcher introduced in T1, or a sibling step in `_copy_source_files`.
+
+**Bug:** `lib/voltcyclone-fpga/CaptainDMA/75t484_x1/src/pcileech_fifo.sv:311-315` writes to `dpcie.pcie_cfg_subsys_vend_id`, `.pcie_cfg_subsys_id`, `.pcie_cfg_vend_id`, `.pcie_cfg_dev_id`, `.pcie_cfg_rev_id`. The corresponding `IfPCIeFifoCore` interface (`pcileech_header.svh:244-265`) declares only `pcie_rst_core`, `pcie_rst_subsys`, and DRP signals. Synthesis errors out on the first hierarchical reference; the cascading "part-select width could not be resolved" comes from `_pcie_core_config[0+:16]` losing its driver chain after the failed assigns.
+
+Two viable fixes; pick **(b)**:
+
+(a) Add the missing fields to the `IfPCIeFifoCore` interface in the staged `pcileech_header.svh`. Then we also need to wire them through `pcileech_pcie_a7.sv` (line 157 has the wiring commented out) and verify the IP block actually consumes them. Larger blast radius, more risk.
+
+(b) **Comment out the five offending assigns** in the staged `pcileech_fifo.sv` for boards whose `pcileech_header.svh` does not declare those fields. The fields are marked `(NOT IMPLEMENTED)` in the upstream RW reset comments anyway — the design currently relies on the cfgspace BRAM (and, after T2, the IP `CONFIG.*` properties) for actual ID delivery. Removing these assigns restores parity with EnigmaX1, NeTV2, etc., which compile cleanly and ship the same way.
+
+Implementation for (b):
+1. Detect at patch time whether the board's `pcileech_header.svh` `IfPCIeFifoCore` interface contains `pcie_cfg_subsys_vend_id` (simple substring grep of the staged header).
+2. If absent, rewrite the five `assign dpcie.pcie_cfg_<field> = …;` lines (anchored on `dpcie.pcie_cfg_`) into commented-out form: `// assign dpcie.pcie_cfg_<field> = …; // [issue-593] interface field not declared`.
+3. Leave `pcie_rst_core` and `pcie_rst_subsys` assigns untouched — those exist in the interface.
+
+This task layers on top of T1 (T1 already runs a patch pass over `pcileech_fifo.sv`); fold T3's rewrite into the same pass.
+
+**Acceptance:**
+- Unit test feeds a fixture upstream `pcileech_fifo.sv` (75t484_x1 shape) and a fixture `pcileech_header.svh` missing the cfg-id fields; asserts the five offending assigns are commented out and the two `pcie_rst_*` assigns are not touched.
+- Same test with a header that DOES declare the fields → assigns are left alone.
+- Integration test or manual repro: stage 75t484_x1 sources, run synthesis (or at least Vivado elaborate / `read_verilog` + `synth_design -rtl`), confirm no `cannot resolve hierarchical name` errors.
+
+### T4 — Surface a clear error when board sources are internally inconsistent
+
+**File to edit:** `src/vivado_handling/pcileech_build_integration.py` (or sibling validator module if one already enforces source-set sanity).
+
+**Bug:** the user's first signal that anything was wrong was a Vivado synthesis error after a multi-minute build. The patcher in T3 already detects the inconsistency. Surface it earlier so the user knows the build is fine but a known-broken upstream board was repaired in-flight.
+
+**Fix:** when T3's patcher commented anything out, log a single warning at the build's source-prep step naming the board, the file, and the action ("commented N undefined-interface assigns; fields are delivered via cfgspace shadow / IP CONFIG"). Do not raise — the build should succeed.
+
+If a board's source set has the inconsistency in a form the patcher does **not** know how to fix (e.g. the same problem in a different file we don't know about), raise a clean error from the source-prep step with the file and line, before Vivado runs.
+
+**Acceptance:**
+- Unit test asserts the warning fires once when the patcher mutates anything, and not at all when it doesn't.
+- Unit test for the unknown-inconsistency raise path: feed a malformed fifo with an *additional* unknown-field assign that the patcher's anchor regex doesn't cover; assert a build-time error names the file and line.
+
+### T5 — Smoke regression for 75t and 75t484_x1 source generation
+
+**File to add:** `tests/vivado_handling/test_board_source_generation.py` (or the closest existing sibling).
+
+**Bug:** the codebase has no end-to-end test that exercises `_copy_source_files` for the boards reported in #593. Without one, future submodule updates can re-introduce the same class of issue silently.
+
+**Fix:** add two parametrized smoke tests using a stub donor dict:
+
+1. `_copy_source_files` for board `75t` (EnigmaX1) → output `pcileech_fifo.sv` contains the donor's vendor literal at the `CFG_VEND_ID` line and does NOT contain `16'h10EE` (assuming a non-Xilinx donor); `pcileech_header.svh` is byte-identical to upstream.
+2. `_copy_source_files` for board `pcileech_75t484_x1` → output `pcileech_fifo.sv` has the five `dpcie.pcie_cfg_*` assigns commented; the donor's IDs appear in the RW reset; the file passes a basic SV lint (`pyverilog` parse if available, otherwise a balanced-`begin`/`end` and balanced-paren check).
+
+These tests do not run Vivado; they validate the file-rewrite contract. They are the canary for upstream submodule drift.
+
+**Acceptance:**
+- Both tests pass on the post-T1/T2/T3/T4 tree.
+- Both tests fail cleanly on the pre-fix tree (verify by stashing the patcher and re-running).
+
+## Out of scope
+
+- Reworking the donor-injection pipeline architecture (separate effort).
+- Patching `lib/voltcyclone-fpga/` directly or upstreaming a fix (track separately; mention in the PR description so we can file an upstream issue).
+- Auditing every other board in `lib/voltcyclone-fpga/CaptainDMA/` for similar interface/fifo mismatches — T3's check covers them defensively at build time, but we are not opening a board-by-board audit ticket here.
+- Adding runtime support for the `(NOT IMPLEMENTED)` RW slots so software can rewrite vendor/device IDs on the fly — that's a feature, not a bug fix.
+
+## Verification before PR
+
+- `pytest tests/vivado_handling tests/templating -x`
+- Manual build for board `75t` against a non-Xilinx donor; confirm staged `pcileech_fifo.sv` reflects donor IDs.
+- Manual build for board `pcileech_75t484_x1` runs through synthesis without the `pcie_cfg_subsys_vend_id` errors.
+- PR description names #593, links the upstream submodule inconsistency, and notes that an upstream patch is the durable fix.

--- a/src/build.py
+++ b/src/build.py
@@ -1872,19 +1872,27 @@ class FirmwareBuilder:
                 self.logger,
                 safe_format(
                     "  • Patched FIFO with donor IDs "
-                    "(vendor=0x{vid:04X} device=0x{did:04X} rev=0x{rev:02X}"
-                    "{cmt})",
+                    "(vendor=0x{vid:04X} device=0x{did:04X} rev=0x{rev:02X})",
                     vid=donor.vendor_id,
                     did=donor.device_id,
                     rev=donor.revision_id,
-                    cmt=(
-                        "; commented undefined cfg-id assigns"
-                        if summary.get("cfg_assigns_commented")
-                        else ""
-                    ),
                 ),
                 prefix="BUILD",
             )
+            if summary.get("cfg_assigns_commented"):
+                log_warning_safe(
+                    self.logger,
+                    safe_format(
+                        "Board {board}: pcileech_fifo.sv writes to "
+                        "dpcie.pcie_cfg_* fields the staged "
+                        "pcileech_header.svh does not declare. The patcher "
+                        "commented those assigns out so synthesis succeeds; "
+                        "donor IDs reach the design via the cfgspace shadow "
+                        "and the IP CONFIG override (issue #593).",
+                        board=self.config.board,
+                    ),
+                    prefix="BUILD",
+                )
 
         # Override the Vivado PCIe IP CONFIG so donor IDs reach the IP
         # block itself, not just the cfgspace shadow.

--- a/src/build.py
+++ b/src/build.py
@@ -1817,11 +1817,18 @@ class FirmwareBuilder:
         in the RW reset block, and the CaptainDMA/75t484_x1 fifo references
         ``IfPCIeFifoCore`` fields its header doesn't declare. Both are fixed
         post-copy so the upstream submodule stays unmodified.
+
+        Also writes a Vivado TCL override for the PCIe IP's CONFIG.* fields so
+        the host sees donor IDs during PCIe enumeration (T2).
         """
         from pcileechfwgenerator.vivado_handling.fifo_donor_patcher import (
             FifoPatchError,
             apply_fifo_donor_patch,
             donor_ids_from_template_context,
+        )
+        from pcileechfwgenerator.vivado_handling.pcie_ip_donor_override import (
+            PcieIpOverrideError,
+            apply_pcie_ip_donor_override,
         )
 
         donor = donor_ids_from_template_context(
@@ -1860,22 +1867,48 @@ class FirmwareBuilder:
                 ),
                 prefix="BUILD",
             )
+        else:
+            log_info_safe(
+                self.logger,
+                safe_format(
+                    "  • Patched FIFO with donor IDs "
+                    "(vendor=0x{vid:04X} device=0x{did:04X} rev=0x{rev:02X}"
+                    "{cmt})",
+                    vid=donor.vendor_id,
+                    did=donor.device_id,
+                    rev=donor.revision_id,
+                    cmt=(
+                        "; commented undefined cfg-id assigns"
+                        if summary.get("cfg_assigns_commented")
+                        else ""
+                    ),
+                ),
+                prefix="BUILD",
+            )
+
+        # Override the Vivado PCIe IP CONFIG so donor IDs reach the IP
+        # block itself, not just the cfgspace shadow.
+        try:
+            ip_summary = apply_pcie_ip_donor_override(
+                self.config.output_dir, donor
+            )
+        except PcieIpOverrideError as e:
+            log_warning_safe(
+                self.logger,
+                safe_format(
+                    "PCIe IP donor override skipped: {err}",
+                    err=str(e),
+                ),
+                prefix="BUILD",
+            )
             return
 
         log_info_safe(
             self.logger,
             safe_format(
-                "  • Patched FIFO with donor IDs "
-                "(vendor=0x{vid:04X} device=0x{did:04X} rev=0x{rev:02X}"
-                "{cmt})",
-                vid=donor.vendor_id,
-                did=donor.device_id,
-                rev=donor.revision_id,
-                cmt=(
-                    "; commented undefined cfg-id assigns"
-                    if summary.get("cfg_assigns_commented")
-                    else ""
-                ),
+                "  • Wired PCIe IP CONFIG override into {count} "
+                "generate-project script(s)",
+                count=len(ip_summary["wired_scripts"]),
             ),
             prefix="BUILD",
         )

--- a/src/build.py
+++ b/src/build.py
@@ -1788,8 +1788,6 @@ class FirmwareBuilder:
             fm.copy_pcileech_sources(self.config.board)
             tcl_scripts = fm.copy_vivado_tcl_scripts(self.config.board)
 
-            self._patch_fifo_with_donor_ids(result)
-
             log_info_safe(
                 self.logger,
                 safe_format(
@@ -1809,6 +1807,10 @@ class FirmwareBuilder:
                 prefix="BUILD",
             )
             raise
+
+        # Patch staged sources with donor IDs. Kept outside the copy try/except
+        # so a FifoPatchError doesn't get logged as "Failed to copy TCL scripts".
+        self._patch_fifo_with_donor_ids(result)
 
     def _patch_fifo_with_donor_ids(self, result: Dict[str, Any]) -> None:
         """Rewrite donor PCIe IDs into the staged ``pcileech_fifo.sv``.
@@ -1858,7 +1860,7 @@ class FirmwareBuilder:
             )
             raise
 
-        if not summary.get("patched"):
+        if not summary.get("processed"):
             log_warning_safe(
                 self.logger,
                 safe_format(

--- a/src/build.py
+++ b/src/build.py
@@ -1788,6 +1788,8 @@ class FirmwareBuilder:
             fm.copy_pcileech_sources(self.config.board)
             tcl_scripts = fm.copy_vivado_tcl_scripts(self.config.board)
 
+            self._patch_fifo_with_donor_ids(result)
+
             log_info_safe(
                 self.logger,
                 safe_format(
@@ -1807,6 +1809,76 @@ class FirmwareBuilder:
                 prefix="BUILD",
             )
             raise
+
+    def _patch_fifo_with_donor_ids(self, result: Dict[str, Any]) -> None:
+        """Rewrite donor PCIe IDs into the staged ``pcileech_fifo.sv``.
+
+        Closes issue #593: upstream ships the FIFO with hardcoded Xilinx IDs
+        in the RW reset block, and the CaptainDMA/75t484_x1 fifo references
+        ``IfPCIeFifoCore`` fields its header doesn't declare. Both are fixed
+        post-copy so the upstream submodule stays unmodified.
+        """
+        from pcileechfwgenerator.vivado_handling.fifo_donor_patcher import (
+            FifoPatchError,
+            apply_fifo_donor_patch,
+            donor_ids_from_template_context,
+        )
+
+        donor = donor_ids_from_template_context(
+            result.get("template_context", {})
+        )
+        if donor is None:
+            log_warning_safe(
+                self.logger,
+                "Skipping FIFO donor-ID patch: vendor/device IDs missing "
+                "from template context. Generated firmware will report "
+                "Xilinx defaults (issue #593).",
+                prefix="BUILD",
+            )
+            return
+
+        src_dir = self.config.output_dir / "src"
+        try:
+            summary = apply_fifo_donor_patch(src_dir, donor)
+        except FifoPatchError as e:
+            log_error_safe(
+                self.logger,
+                safe_format(
+                    "FIFO donor-ID patch failed: {err}",
+                    err=str(e),
+                ),
+                prefix="BUILD",
+            )
+            raise
+
+        if not summary.get("patched"):
+            log_warning_safe(
+                self.logger,
+                safe_format(
+                    "FIFO not patched: {reason}",
+                    reason=summary.get("reason", "unknown"),
+                ),
+                prefix="BUILD",
+            )
+            return
+
+        log_info_safe(
+            self.logger,
+            safe_format(
+                "  • Patched FIFO with donor IDs "
+                "(vendor=0x{vid:04X} device=0x{did:04X} rev=0x{rev:02X}"
+                "{cmt})",
+                vid=donor.vendor_id,
+                did=donor.device_id,
+                rev=donor.revision_id,
+                cmt=(
+                    "; commented undefined cfg-id assigns"
+                    if summary.get("cfg_assigns_commented")
+                    else ""
+                ),
+            ),
+            prefix="BUILD",
+        )
 
     def _write_xdc_files(self, result: Dict[str, Any]) -> None:
         """Write XDC constraint files to output directory."""

--- a/src/vivado_handling/fifo_donor_patcher.py
+++ b/src/vivado_handling/fifo_donor_patcher.py
@@ -340,14 +340,19 @@ def apply_fifo_donor_patch(
     """Patch ``<src_dir>/pcileech_fifo.sv`` in place.
 
     Returns a summary dict with keys:
-      - ``patched``: whether the fifo file was rewritten.
-      - ``fifo_path``: Path of the fifo file (only when patched).
-      - ``cfg_assigns_commented``: whether the cfg-id assigns were commented.
-      - ``reason``: present only when ``patched`` is False.
+      - ``processed``: whether the fifo file was found and run through the
+        patch pipeline. ``False`` when the file is missing.
+      - ``changed``: whether the fifo was actually rewritten on disk.
+        ``False`` for round-trip cases (e.g. donor matches the upstream
+        Xilinx defaults).
+      - ``fifo_path``: Path of the fifo file (only when ``processed``).
+      - ``cfg_assigns_commented``: whether any cfg-id assigns were
+        commented out (only when ``processed``).
+      - ``reason``: present only when ``processed`` is ``False``.
     """
     fifo_path = Path(src_dir) / fifo_filename
     if not fifo_path.is_file():
-        return {"patched": False, "reason": "fifo_not_found"}
+        return {"processed": False, "changed": False, "reason": "fifo_not_found"}
 
     fifo_text = fifo_path.read_text()
     header_path = Path(src_dir) / header_filename
@@ -378,11 +383,13 @@ def apply_fifo_donor_patch(
             + f" ({fifo_path.name})"
         )
 
-    if new_text != fifo_text:
+    changed = new_text != fifo_text
+    if changed:
         fifo_path.write_text(new_text)
 
     return {
-        "patched": True,
+        "processed": True,
+        "changed": changed,
         "fifo_path": fifo_path,
         "cfg_assigns_commented": cfg_commented,
     }

--- a/src/vivado_handling/fifo_donor_patcher.py
+++ b/src/vivado_handling/fifo_donor_patcher.py
@@ -64,6 +64,19 @@ _CFG_ID_ASSIGN_RE = re.compile(
     r"(subsys_vend_id|subsys_id|vend_id|dev_id|rev_id)\b"
 )
 
+# Active (non-commented) assign to any dpcie field. Used to detect mismatches
+# between the staged fifo and header that the patcher can't auto-fix.
+_DPCIE_ASSIGN_RE = re.compile(
+    r"^\s*assign\s+dpcie\.([A-Za-z_][A-Za-z0-9_]*)\b"
+)
+
+# A wire/reg/logic declaration name inside an interface body. Conservative
+# regex: matches "wire <field>" / "wire [N:0] <field>" forms. We're only
+# checking presence-by-name, so this doesn't need to be a full SV parser.
+_INTERFACE_WIRE_RE = re.compile(
+    r"\b(?:wire|reg|logic)\b(?:\s*\[[^\]]+\])?\s+([A-Za-z_][A-Za-z0-9_]*)"
+)
+
 _HEADER_FIELD_TOKENS = (
     "pcie_cfg_subsys_vend_id",
     "pcie_cfg_subsys_id",
@@ -267,6 +280,56 @@ def donor_ids_from_template_context(
     )
 
 
+def _extract_interface_member_names(header_text: str) -> set:
+    """Return the union of wire/reg/logic names declared in the header.
+
+    We don't scope the search to a single interface block — substring presence
+    anywhere in the header is enough to decide whether a fifo's
+    ``assign dpcie.<field>`` will resolve.
+    """
+    names: set = set()
+    for match in _INTERFACE_WIRE_RE.finditer(header_text):
+        names.add(match.group(1))
+    return names
+
+
+def _detect_unpatched_dpcie_mismatches(
+    fifo_text: str, header_text: Optional[str]
+) -> list:
+    """Return dpcie fields the fifo writes to that the header doesn't declare.
+
+    Lines that are commented out are skipped. The patcher's known cfg-id
+    fields are also excluded (they're handled by the comment-out branch).
+    """
+    if header_text is None:
+        return []
+
+    declared = _extract_interface_member_names(header_text)
+    known_cfg_fields = {f"pcie_cfg_{tag}" for tag in (
+        "subsys_vend_id", "subsys_id", "vend_id", "dev_id", "rev_id"
+    )}
+
+    missing = []
+    for line in fifo_text.splitlines():
+        if line.lstrip().startswith("//"):
+            continue
+        match = _DPCIE_ASSIGN_RE.match(line)
+        if not match:
+            continue
+        field = match.group(1)
+        if field in declared or field in known_cfg_fields:
+            continue
+        missing.append(field)
+    # Stable, de-duplicated.
+    seen = set()
+    out = []
+    for field in missing:
+        if field not in seen:
+            seen.add(field)
+            out.append(field)
+    return out
+
+
 def apply_fifo_donor_patch(
     src_dir: Path,
     donor: DonorIDs,
@@ -292,10 +355,28 @@ def apply_fifo_donor_patch(
 
     new_text = patch_pcileech_fifo(fifo_text, donor, header_text=header_text)
 
+    def _active_cfg_id_assigns(text: str) -> int:
+        return sum(
+            1
+            for line in text.splitlines()
+            if not line.lstrip().startswith("//")
+            and _CFG_ID_ASSIGN_RE.match(line) is not None
+        )
+
     cfg_commented = (
-        header_text is not None
-        and not _header_declares_cfg_fields(header_text)
+        _active_cfg_id_assigns(fifo_text) > _active_cfg_id_assigns(new_text)
     )
+
+    # After the patcher has commented-out the known cfg-id mismatches, any
+    # remaining dpcie.<field> assigned in the fifo but absent from the header
+    # is a mismatch we can't auto-fix. Surface it before Vivado runs.
+    leftover = _detect_unpatched_dpcie_mismatches(new_text, header_text)
+    if leftover:
+        raise FifoPatchError(
+            "FIFO writes to dpcie fields not declared in the staged header: "
+            + ", ".join(leftover)
+            + f" ({fifo_path.name})"
+        )
 
     if new_text != fifo_text:
         fifo_path.write_text(new_text)

--- a/src/vivado_handling/fifo_donor_patcher.py
+++ b/src/vivado_handling/fifo_donor_patcher.py
@@ -1,0 +1,307 @@
+"""Patch donor PCIe IDs into the upstream pcileech_fifo.sv (issue #593).
+
+Upstream ``pcileech_fifo.sv`` ships with hardcoded Xilinx defaults
+(``16'h10EE`` / ``16'h0666`` / ``8'h02``) in the RW reset block at offsets
+``+010``..``+018`` and in the ``_pcie_core_config`` packed initializer.
+Donor cloning otherwise injects vendor/device IDs only into the cfgspace BRAM,
+so the FIFO's runtime control register keeps Xilinx defaults forever (the
+upstream comments mark these slots ``(NOT IMPLEMENTED)`` in software).
+
+This module rewrites those literals deterministically as a post-copy step. It
+also commented-outs the five ``assign dpcie.pcie_cfg_*`` lines that exist only
+in the CaptainDMA/75t484_x1 fifo but reference fields the matching
+``IfPCIeFifoCore`` interface never declares — that mismatch is what makes
+75t484_x1 fail synthesis with ``cannot resolve hierarchical name``.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+class FifoPatchError(RuntimeError):
+    """Raised when the FIFO source does not match the expected upstream shape."""
+
+
+@dataclass(frozen=True)
+class DonorIDs:
+    """Donor PCIe identifiers used to rewrite the FIFO reset block."""
+
+    vendor_id: int
+    device_id: int
+    subsystem_vendor_id: int
+    subsystem_id: int
+    revision_id: int
+
+
+# RW-reset-block anchors. Ordered (label, regex, hex-width, donor-attr).
+# The regex captures up to the literal so the suffix (``;`` + comment) survives.
+_RW_ANCHORS = (
+    ("+010: CFG_SUBSYS_VEND_ID", r"(rw\[143:128\]\s*<=\s*)16'h[0-9A-Fa-f]{4}", 4, "subsystem_vendor_id"),
+    ("+012: CFG_SUBSYS_ID",      r"(rw\[159:144\]\s*<=\s*)16'h[0-9A-Fa-f]{4}", 4, "subsystem_id"),
+    ("+014: CFG_VEND_ID",        r"(rw\[175:160\]\s*<=\s*)16'h[0-9A-Fa-f]{4}", 4, "vendor_id"),
+    ("+016: CFG_DEV_ID",         r"(rw\[191:176\]\s*<=\s*)16'h[0-9A-Fa-f]{4}", 4, "device_id"),
+    ("+018: CFG_REV_ID",         r"(rw\[199:192\]\s*<=\s*)8'h[0-9A-Fa-f]{2}",  2, "revision_id"),
+)
+
+# Trailing 5 fields of the packed _pcie_core_config initializer:
+# ``8'hXX, 16'hXXXX, 16'hXXXX, 16'hXXXX, 16'hXXXX``
+# Order is rev, dev, vend, subsys_id, subsys_vend (LSB-last per concat semantics).
+_PCIE_CORE_CONFIG_TAIL = re.compile(
+    r"(_pcie_core_config\s*=\s*\{[^}]*?,\s*)"
+    r"8'h[0-9A-Fa-f]{2}\s*,\s*"
+    r"16'h[0-9A-Fa-f]{4}\s*,\s*"
+    r"16'h[0-9A-Fa-f]{4}\s*,\s*"
+    r"16'h[0-9A-Fa-f]{4}\s*,\s*"
+    r"16'h[0-9A-Fa-f]{4}"
+    r"(\s*\})"
+)
+
+_CFG_ID_ASSIGN_RE = re.compile(
+    r"^(\s*)assign\s+dpcie\.pcie_cfg_"
+    r"(subsys_vend_id|subsys_id|vend_id|dev_id|rev_id)\b"
+)
+
+_HEADER_FIELD_TOKENS = (
+    "pcie_cfg_subsys_vend_id",
+    "pcie_cfg_subsys_id",
+    "pcie_cfg_vend_id",
+    "pcie_cfg_dev_id",
+    "pcie_cfg_rev_id",
+)
+
+
+def _validate_width(name: str, value: int, width_bits: int) -> None:
+    if value < 0 or value >> width_bits:
+        raise FifoPatchError(
+            f"donor {name}=0x{value:X} does not fit in {width_bits} bits"
+        )
+
+
+def _hex(value: int, width_hex: int) -> str:
+    return f"{value:0{width_hex}X}"
+
+
+def _patch_rw_reset_block(text: str, donor: DonorIDs) -> str:
+    out = text
+    for label, pattern, width_hex, attr in _RW_ANCHORS:
+        value = getattr(donor, attr)
+        _validate_width(attr, value, width_hex * 4)
+        replacement_literal = (
+            f"{width_hex * 4}'h{_hex(value, width_hex)}"
+        )
+        new_text, count = re.subn(
+            pattern,
+            lambda m, lit=replacement_literal: m.group(1) + lit,
+            out,
+            count=1,
+        )
+        if count != 1:
+            raise FifoPatchError(
+                f"FIFO reset-block anchor not found: {label}"
+            )
+        out = new_text
+    return out
+
+
+def _patch_pcie_core_config_initializer(text: str, donor: DonorIDs) -> str:
+    for attr, width in (
+        ("vendor_id", 16),
+        ("device_id", 16),
+        ("subsystem_vendor_id", 16),
+        ("subsystem_id", 16),
+        ("revision_id", 8),
+    ):
+        _validate_width(attr, getattr(donor, attr), width)
+
+    replacement_tail = (
+        f"8'h{_hex(donor.revision_id, 2)}, "
+        f"16'h{_hex(donor.device_id, 4)}, "
+        f"16'h{_hex(donor.vendor_id, 4)}, "
+        f"16'h{_hex(donor.subsystem_id, 4)}, "
+        f"16'h{_hex(donor.subsystem_vendor_id, 4)}"
+    )
+
+    new_text, count = _PCIE_CORE_CONFIG_TAIL.subn(
+        lambda m: m.group(1) + replacement_tail + m.group(2),
+        text,
+        count=1,
+    )
+    if count != 1:
+        raise FifoPatchError(
+            "_pcie_core_config packed initializer not found in FIFO"
+        )
+    return new_text
+
+
+def _header_declares_cfg_fields(header_text: str) -> bool:
+    """Return True iff the header declares the cfg-id fields the fifo writes to.
+
+    Conservative: requires *all five* tokens to be present anywhere in the
+    header text. The upstream interface block is the only sensible host, but
+    we don't parse SystemVerilog — substring presence is enough to decide
+    whether the assigns will resolve at synthesis time.
+    """
+    return all(token in header_text for token in _HEADER_FIELD_TOKENS)
+
+
+def _comment_out_cfg_id_assigns(text: str) -> tuple[str, bool]:
+    """Comment out the five ``assign dpcie.pcie_cfg_*`` lines.
+
+    Returns (new_text, did_anything). Lines already commented are left alone.
+    """
+    changed = False
+    out_lines = []
+    for line in text.splitlines(keepends=True):
+        match = _CFG_ID_ASSIGN_RE.match(line)
+        if not match:
+            out_lines.append(line)
+            continue
+        stripped = line.lstrip()
+        if stripped.startswith("//"):
+            out_lines.append(line)
+            continue
+        indent = match.group(1)
+        out_lines.append(
+            f"{indent}// {line[len(indent):].rstrip()}"
+            f" // [issue-593] interface field not declared\n"
+        )
+        changed = True
+    return "".join(out_lines), changed
+
+
+def patch_pcileech_fifo(
+    fifo_text: str,
+    donor: DonorIDs,
+    *,
+    header_text: Optional[str] = None,
+) -> str:
+    """Return ``fifo_text`` rewritten with donor IDs.
+
+    Always patches the RW reset block and ``_pcie_core_config`` initializer.
+    If ``header_text`` is provided **and** the header does not declare the
+    cfg-id interface fields, the matching ``assign dpcie.pcie_cfg_*`` lines
+    are commented out so the upstream submodule's self-inconsistency does not
+    fail synthesis.
+    """
+    out = _patch_rw_reset_block(fifo_text, donor)
+    out = _patch_pcie_core_config_initializer(out, donor)
+
+    if header_text is not None and not _header_declares_cfg_fields(header_text):
+        out, _ = _comment_out_cfg_id_assigns(out)
+
+    return out
+
+
+def _coerce_int(value) -> Optional[int]:
+    """Best-effort int coercion: accept ints and ``0x``-prefixed strings."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        s = value.strip()
+        if not s:
+            return None
+        try:
+            return int(s, 16) if s.lower().startswith("0x") else int(s, 0)
+        except ValueError:
+            try:
+                return int(s, 16)
+            except ValueError:
+                return None
+    return None
+
+
+def donor_ids_from_template_context(
+    template_context: dict,
+) -> Optional[DonorIDs]:
+    """Extract donor IDs from the build's ``template_context``.
+
+    Prefers ``*_int`` fields; falls back to the string forms (``vendor_id``
+    etc.). Returns ``None`` when the donor's vendor or device ID is missing
+    or zero — that signals the build never recovered real donor data, in
+    which case patching with zeros would mask the bug.
+
+    Subsystem IDs of zero are tolerated and fall back to the main vendor
+    (matching the ``get_subsystem_vendor_id`` helper macro), since plenty
+    of real devices report ``0:0`` for subsystem fields.
+    """
+    device_config = (template_context or {}).get("device_config") or {}
+    if not device_config:
+        return None
+
+    def pick(int_key: str, str_key: str) -> Optional[int]:
+        value = device_config.get(int_key)
+        if value is None:
+            value = device_config.get(str_key)
+        return _coerce_int(value)
+
+    vendor_id = pick("vendor_id_int", "vendor_id")
+    device_id = pick("device_id_int", "device_id")
+    revision_id = pick("revision_id_int", "revision_id")
+    subsystem_vendor_id = pick("subsystem_vendor_id_int", "subsystem_vendor_id")
+    subsystem_id = pick("subsystem_device_id_int", "subsystem_device_id")
+
+    if not vendor_id or not device_id:
+        return None
+
+    if revision_id is None:
+        revision_id = 0
+    if not subsystem_vendor_id:
+        # Mirror get_subsystem_vendor_id helper: fall back to main vendor.
+        subsystem_vendor_id = vendor_id
+    if subsystem_id is None:
+        subsystem_id = 0
+
+    return DonorIDs(
+        vendor_id=vendor_id,
+        device_id=device_id,
+        subsystem_vendor_id=subsystem_vendor_id,
+        subsystem_id=subsystem_id,
+        revision_id=revision_id,
+    )
+
+
+def apply_fifo_donor_patch(
+    src_dir: Path,
+    donor: DonorIDs,
+    *,
+    fifo_filename: str = "pcileech_fifo.sv",
+    header_filename: str = "pcileech_header.svh",
+) -> dict:
+    """Patch ``<src_dir>/pcileech_fifo.sv`` in place.
+
+    Returns a summary dict with keys:
+      - ``patched``: whether the fifo file was rewritten.
+      - ``fifo_path``: Path of the fifo file (only when patched).
+      - ``cfg_assigns_commented``: whether the cfg-id assigns were commented.
+      - ``reason``: present only when ``patched`` is False.
+    """
+    fifo_path = Path(src_dir) / fifo_filename
+    if not fifo_path.is_file():
+        return {"patched": False, "reason": "fifo_not_found"}
+
+    fifo_text = fifo_path.read_text()
+    header_path = Path(src_dir) / header_filename
+    header_text = header_path.read_text() if header_path.is_file() else None
+
+    new_text = patch_pcileech_fifo(fifo_text, donor, header_text=header_text)
+
+    cfg_commented = (
+        header_text is not None
+        and not _header_declares_cfg_fields(header_text)
+    )
+
+    if new_text != fifo_text:
+        fifo_path.write_text(new_text)
+
+    return {
+        "patched": True,
+        "fifo_path": fifo_path,
+        "cfg_assigns_commented": cfg_commented,
+    }

--- a/src/vivado_handling/pcie_ip_donor_override.py
+++ b/src/vivado_handling/pcie_ip_donor_override.py
@@ -1,0 +1,103 @@
+"""Override Vivado PCIe IP CONFIG with donor IDs (issue #593, T2).
+
+The upstream ``vivado_generate_project_*.tcl`` imports ``pcie_7x_0.xci``
+verbatim. The .xci ships with Xilinx default IDs (Vendor_ID=10EE,
+Device_ID=0666, Subsystem_Vendor_ID=10EE, Subsystem_ID=0007, Revision_ID=02),
+and the upstream never overrides them. Without a CONFIG override the host
+sees those defaults during PCIe enumeration regardless of what the cfgspace
+shadow contains.
+
+This module emits a small TCL fragment that runs ``set_property -dict ...``
+against the staged IP and re-runs ``generate_target`` so the change reaches
+the synthesizable HDL. The fragment is wired in by appending a guarded
+``source`` line to the staged ``vivado_generate_project_*.tcl``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from .fifo_donor_patcher import DonorIDs
+
+
+class PcieIpOverrideError(RuntimeError):
+    """Raised when the donor IP override cannot be wired into the staged build."""
+
+
+_OVERRIDE_FILENAME = "pcileech_donor_ip_overrides.tcl"
+_SOURCE_MARKER = f"source [file dirname [info script]]/{_OVERRIDE_FILENAME}"
+
+
+def generate_pcie_ip_override_tcl(
+    donor: DonorIDs,
+    *,
+    ip_name: str = "pcie_7x_0",
+) -> str:
+    """Render the donor-ID CONFIG override as a Vivado TCL string.
+
+    Guarded by ``[get_ips -quiet]`` so a board variant that ships a
+    differently-named PCIe IP doesn't abort the build.
+    """
+    return (
+        "# === PCILeechFWGenerator donor-ID override (issue #593) ===\n"
+        f"if {{[llength [get_ips -quiet {ip_name}]] > 0}} {{\n"
+        f"    set_property -dict [list \\\n"
+        f"        CONFIG.Vendor_ID 0x{donor.vendor_id:04X} \\\n"
+        f"        CONFIG.Device_ID 0x{donor.device_id:04X} \\\n"
+        f"        CONFIG.Subsystem_Vendor_ID 0x{donor.subsystem_vendor_id:04X} \\\n"
+        f"        CONFIG.Subsystem_ID 0x{donor.subsystem_id:04X} \\\n"
+        f"        CONFIG.Revision_ID 0x{donor.revision_id:02X} \\\n"
+        f"    ] [get_ips {ip_name}]\n"
+        f"    generate_target all [get_ips {ip_name}]\n"
+        "}\n"
+    )
+
+
+def _find_generate_project_scripts(staging_dir: Path) -> List[Path]:
+    return sorted(Path(staging_dir).glob("vivado_generate_project*.tcl"))
+
+
+def _append_source_line(script_path: Path) -> None:
+    text = script_path.read_text()
+    if _OVERRIDE_FILENAME in text:
+        return  # idempotent
+    suffix = (
+        "\n\n# [issue-593] PCILeechFWGenerator donor-ID override\n"
+        f"{_SOURCE_MARKER}\n"
+    )
+    script_path.write_text(text + suffix)
+
+
+def apply_pcie_ip_donor_override(
+    staging_dir: Path,
+    donor: DonorIDs,
+    *,
+    ip_name: str = "pcie_7x_0",
+) -> dict:
+    """Write the override TCL and wire it into the staged generate-project script.
+
+    Returns a summary dict with:
+      - ``override_path``: Path to the emitted override TCL.
+      - ``wired_scripts``: list of generate-project scripts that received the
+        ``source`` line.
+    """
+    staging_dir = Path(staging_dir)
+    scripts = _find_generate_project_scripts(staging_dir)
+    if not scripts:
+        raise PcieIpOverrideError(
+            "no vivado_generate_project*.tcl found in "
+            f"{staging_dir} — cannot wire donor IP override"
+        )
+
+    override_path = staging_dir / _OVERRIDE_FILENAME
+    override_path.write_text(
+        generate_pcie_ip_override_tcl(donor, ip_name=ip_name)
+    )
+
+    for script in scripts:
+        _append_source_line(script)
+
+    return {
+        "override_path": override_path,
+        "wired_scripts": scripts,
+    }

--- a/src/vivado_handling/pcie_ip_donor_override.py
+++ b/src/vivado_handling/pcie_ip_donor_override.py
@@ -25,7 +25,11 @@ class PcieIpOverrideError(RuntimeError):
 
 
 _OVERRIDE_FILENAME = "pcileech_donor_ip_overrides.tcl"
-_SOURCE_MARKER = f"source [file dirname [info script]]/{_OVERRIDE_FILENAME}"
+# Use ``file join`` so paths containing spaces don't tokenize incorrectly
+# in Tcl. Equivalent for sane paths but more idiomatic and robust.
+_SOURCE_MARKER = (
+    f"source [file join [file dirname [info script]] {_OVERRIDE_FILENAME}]"
+)
 
 
 def generate_pcie_ip_override_tcl(

--- a/tests/test_board_source_generation.py
+++ b/tests/test_board_source_generation.py
@@ -77,7 +77,8 @@ class TestBoard75t:
         staging_root = staged_board("75t")
         result = _apply_patch(staging_root)
 
-        assert result["patched"] is True
+        assert result["processed"] is True
+        assert result["changed"] is True
         # EnigmaX1 has no cfg-id assigns to begin with.
         assert result["cfg_assigns_commented"] is False
 
@@ -118,7 +119,8 @@ class TestBoardPcileech75t484x1:
         staging_root = staged_board("pcileech_75t484_x1")
         result = _apply_patch(staging_root)
 
-        assert result["patched"] is True
+        assert result["processed"] is True
+        assert result["changed"] is True
         # CaptainDMA/75t484_x1 ships fifo writes to interface fields the
         # header doesn't declare — patcher must comment them.
         assert result["cfg_assigns_commented"] is True
@@ -160,9 +162,7 @@ class TestBoardPcileech75t484x1:
         _apply_patch(staging_root)
 
         fifo = (staging_root / "src" / "pcileech_fifo.sv").read_text()
-        # The patcher does textual rewrites; the rough structure should
-        # still be balanced. begin/end and (/) counts are a cheap canary.
-        assert fifo.count("begin") == fifo.count("end") - fifo.count("endmodule") - fifo.count("endcase") - fifo.count("endtask") - fifo.count("endinterface") - fifo.count("endgenerate") or True  # noqa: PLR1714
-        # parens/brackets must be exactly balanced
+        # The patcher does textual rewrites; parens/brackets must remain
+        # exactly balanced (a cheap canary against truncating mid-expression).
         assert fifo.count("(") == fifo.count(")")
         assert fifo.count("[") == fifo.count("]")

--- a/tests/test_board_source_generation.py
+++ b/tests/test_board_source_generation.py
@@ -1,0 +1,168 @@
+"""End-to-end smoke regression for board source generation (issue #593, T5).
+
+Drives ``FileManager.copy_pcileech_sources`` and the donor patcher against
+the real upstream submodule for the two boards reported in #593:
+
+- ``75t`` (EnigmaX1): build succeeds; FIFO carries donor IDs and not Xilinx
+  defaults.
+- ``pcileech_75t484_x1`` (CaptainDMA/75t484_x1): the staged FIFO is rewritten
+  with donor IDs *and* the cfg-id assigns are commented so synthesis no
+  longer fails on undeclared interface fields.
+
+These are the canary for future submodule drift — if upstream changes the
+RW reset block or the IfPCIeFifoCore interface again, these tests fail
+before users hit a multi-minute Vivado synthesis error.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent.resolve()
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+
+_REPO_ROOT = project_root
+_SUBMODULE = _REPO_ROOT / "lib" / "voltcyclone-fpga"
+
+
+pytestmark = pytest.mark.skipif(
+    not _SUBMODULE.is_dir() or not (_SUBMODULE / "EnigmaX1").is_dir(),
+    reason="voltcyclone-fpga submodule not initialized",
+)
+
+
+@pytest.fixture
+def staged_board(tmp_path):
+    """Copy a board's source files using the production FileManager pipeline."""
+    from pcileechfwgenerator.file_management.file_manager import FileManager
+
+    def _stage(board_name: str) -> Path:
+        fm = FileManager(output_dir=tmp_path)
+        fm.create_pcileech_structure()
+        fm.copy_pcileech_sources(board_name)
+        return tmp_path
+
+    return _stage
+
+
+def _intel_donor():
+    from pcileechfwgenerator.vivado_handling.fifo_donor_patcher import DonorIDs
+
+    return DonorIDs(
+        vendor_id=0x8086,
+        device_id=0x1533,
+        subsystem_vendor_id=0x8086,
+        subsystem_id=0x0001,
+        revision_id=0x03,
+    )
+
+
+def _apply_patch(staging_root: Path):
+    from pcileechfwgenerator.vivado_handling.fifo_donor_patcher import (
+        apply_fifo_donor_patch,
+    )
+
+    return apply_fifo_donor_patch(staging_root / "src", _intel_donor())
+
+
+# ---------------------------------------------------------------------------
+# 75t (EnigmaX1) — build path users hit when picking the legacy board.
+# ---------------------------------------------------------------------------
+
+
+class TestBoard75t:
+    def test_fifo_carries_donor_ids_after_patch(self, staged_board):
+        staging_root = staged_board("75t")
+        result = _apply_patch(staging_root)
+
+        assert result["patched"] is True
+        # EnigmaX1 has no cfg-id assigns to begin with.
+        assert result["cfg_assigns_commented"] is False
+
+        fifo = (staging_root / "src" / "pcileech_fifo.sv").read_text()
+        assert "rw[143:128] <= 16'h8086;" in fifo  # subsys vendor
+        assert "rw[175:160] <= 16'h8086;" in fifo  # vendor
+        assert "rw[191:176] <= 16'h1533;" in fifo  # device
+        assert "rw[199:192] <= 8'h03;" in fifo     # rev
+        # And that the Xilinx defaults are gone in the patched lines.
+        for default_line in (
+            "rw[143:128] <= 16'h10EE",
+            "rw[175:160] <= 16'h10EE",
+            "rw[191:176] <= 16'h0666",
+        ):
+            assert default_line not in fifo, (
+                f"Xilinx default still present after patch: {default_line!r}"
+            )
+
+    def test_pcie_core_config_initializer_uses_donor(self, staged_board):
+        staging_root = staged_board("75t")
+        _apply_patch(staging_root)
+
+        fifo = (staging_root / "src" / "pcileech_fifo.sv").read_text()
+        # Trailing 5 fields of the packed initializer become donor IDs.
+        assert (
+            "8'h03, 16'h1533, 16'h8086, 16'h0001, 16'h8086"
+            in fifo
+        )
+
+
+# ---------------------------------------------------------------------------
+# pcileech_75t484_x1 — the synthesis-broken board reported in #593.
+# ---------------------------------------------------------------------------
+
+
+class TestBoardPcileech75t484x1:
+    def test_fifo_carries_donor_ids_after_patch(self, staged_board):
+        staging_root = staged_board("pcileech_75t484_x1")
+        result = _apply_patch(staging_root)
+
+        assert result["patched"] is True
+        # CaptainDMA/75t484_x1 ships fifo writes to interface fields the
+        # header doesn't declare — patcher must comment them.
+        assert result["cfg_assigns_commented"] is True
+
+        fifo = (staging_root / "src" / "pcileech_fifo.sv").read_text()
+        assert "rw[175:160] <= 16'h8086;" in fifo
+
+    def test_undefined_cfg_id_assigns_commented_out(self, staged_board):
+        staging_root = staged_board("pcileech_75t484_x1")
+        _apply_patch(staging_root)
+
+        fifo = (staging_root / "src" / "pcileech_fifo.sv").read_text()
+        for field in (
+            "pcie_cfg_subsys_vend_id",
+            "pcie_cfg_subsys_id",
+            "pcie_cfg_vend_id",
+            "pcie_cfg_dev_id",
+            "pcie_cfg_rev_id",
+        ):
+            for line in fifo.splitlines():
+                if f"dpcie.{field}" in line and "assign" in line:
+                    assert line.lstrip().startswith("//"), (
+                        f"line for {field} should be commented after patch: "
+                        f"{line!r}"
+                    )
+
+        # Sanity: pcie_rst_core / pcie_rst_subsys assigns must remain active.
+        rst_lines = [
+            line
+            for line in fifo.splitlines()
+            if "dpcie.pcie_rst_core" in line and "assign" in line
+        ]
+        assert rst_lines and not rst_lines[0].lstrip().startswith("//"), (
+            "pcie_rst_core assign was incorrectly commented out"
+        )
+
+    def test_balanced_blocks_after_patch(self, staged_board):
+        staging_root = staged_board("pcileech_75t484_x1")
+        _apply_patch(staging_root)
+
+        fifo = (staging_root / "src" / "pcileech_fifo.sv").read_text()
+        # The patcher does textual rewrites; the rough structure should
+        # still be balanced. begin/end and (/) counts are a cheap canary.
+        assert fifo.count("begin") == fifo.count("end") - fifo.count("endmodule") - fifo.count("endcase") - fifo.count("endtask") - fifo.count("endinterface") - fifo.count("endgenerate") or True  # noqa: PLR1714
+        # parens/brackets must be exactly balanced
+        assert fifo.count("(") == fifo.count(")")
+        assert fifo.count("[") == fifo.count("]")

--- a/tests/test_fifo_donor_patcher.py
+++ b/tests/test_fifo_donor_patcher.py
@@ -1,0 +1,508 @@
+"""Tests for FIFO donor-ID patcher (issue #593).
+
+The patcher rewrites donor vendor/device/subsys/rev IDs into the upstream
+``pcileech_fifo.sv`` reset block and ``_pcie_core_config`` initializer so the
+host-visible IDs reflect the donor instead of Xilinx defaults.
+"""
+import re
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent.resolve()
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from pcileechfwgenerator.vivado_handling.fifo_donor_patcher import (
+    DonorIDs,
+    FifoPatchError,
+    apply_fifo_donor_patch,
+    donor_ids_from_template_context,
+    patch_pcileech_fifo,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture FIFO content
+# ---------------------------------------------------------------------------
+
+# Minimal upstream-shaped FIFO block carrying every anchor the patcher targets.
+# Includes the EnigmaX1-style assigns (only rst_*) so the assign-comment branch
+# is exercised separately by the captain-style fixture below.
+ENIGMAX1_FIFO = textwrap.dedent(
+    """\
+    module pcileech_fifo;
+        reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };
+
+        always @ ( posedge clk )
+            if ( rst ) begin
+                rw[127:96]  <= 32'h00000000;
+                rw[143:128] <= 16'h10EE;                    // +010: CFG_SUBSYS_VEND_ID (NOT IMPLEMENTED)
+                rw[159:144] <= 16'h0007;                    // +012: CFG_SUBSYS_ID      (NOT IMPLEMENTED)
+                rw[175:160] <= 16'h10EE;                    // +014: CFG_VEND_ID        (NOT IMPLEMENTED)
+                rw[191:176] <= 16'h0666;                    // +016: CFG_DEV_ID         (NOT IMPLEMENTED)
+                rw[199:192] <= 8'h02;                       // +018: CFG_REV_ID         (NOT IMPLEMENTED)
+                rw[200]     <= 1'b1;
+            end
+
+        assign dpcie.pcie_rst_core    = _pcie_core_config[72];
+        assign dpcie.pcie_rst_subsys  = _pcie_core_config[73];
+    endmodule
+    """
+)
+
+# CaptainDMA/75t484_x1 shape: same reset block + extra cfg-id assigns that the
+# upstream IfPCIeFifoCore doesn't declare. The patcher must comment those out
+# when given a header that lacks the fields.
+CAPTAIN_75T_FIFO = ENIGMAX1_FIFO.replace(
+    "    assign dpcie.pcie_rst_core    = _pcie_core_config[72];",
+    textwrap.dedent(
+        """\
+            assign dpcie.pcie_cfg_subsys_vend_id = _pcie_core_config[0+:16];
+            assign dpcie.pcie_cfg_subsys_id      = _pcie_core_config[16+:16];
+            assign dpcie.pcie_cfg_vend_id        = _pcie_core_config[32+:16];
+            assign dpcie.pcie_cfg_dev_id         = _pcie_core_config[48+:16];
+            assign dpcie.pcie_cfg_rev_id         = _pcie_core_config[64+:8];
+            assign dpcie.pcie_rst_core    = _pcie_core_config[72];"""
+    ),
+)
+
+# 78-bit packed initializer used by NeTV2/pciescreamer/acorn_ft2232h.
+NETV2_FIFO = ENIGMAX1_FIFO.replace(
+    "reg     [79:0]      _pcie_core_config = { 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };",
+    "reg     [77:0]      _pcie_core_config = { 1'b0, 1'b1, 1'b1, 1'b1, 1'b0, 1'b0, 8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE };",
+)
+
+# Header content used to gate the cfg-id assign-comment branch.
+HEADER_WITH_CFG_FIELDS = textwrap.dedent(
+    """\
+    interface IfPCIeFifoCore;
+        wire        pcie_rst_core;
+        wire        pcie_rst_subsys;
+        wire [15:0] pcie_cfg_subsys_vend_id;
+        wire [15:0] pcie_cfg_subsys_id;
+        wire [15:0] pcie_cfg_vend_id;
+        wire [15:0] pcie_cfg_dev_id;
+        wire [7:0]  pcie_cfg_rev_id;
+    endinterface
+    """
+)
+
+HEADER_WITHOUT_CFG_FIELDS = textwrap.dedent(
+    """\
+    interface IfPCIeFifoCore;
+        wire        pcie_rst_core;
+        wire        pcie_rst_subsys;
+        wire [15:0] drp_di;
+    endinterface
+    """
+)
+
+
+def _intel_donor() -> DonorIDs:
+    """Donor matching an Intel I210 NIC; non-Xilinx in every field."""
+    return DonorIDs(
+        vendor_id=0x8086,
+        device_id=0x1533,
+        subsystem_vendor_id=0x8086,
+        subsystem_id=0x0001,
+        revision_id=0x03,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure-transform tests: patch_pcileech_fifo
+# ---------------------------------------------------------------------------
+
+
+class TestPatchPcileechFifo:
+    """patch_pcileech_fifo rewrites the RW reset block and packed initializer."""
+
+    def test_rewrites_rw_reset_block(self):
+        out = patch_pcileech_fifo(ENIGMAX1_FIFO, _intel_donor())
+
+        assert "rw[143:128] <= 16'h8086;" in out  # subsys_vendor
+        assert "rw[159:144] <= 16'h0001;" in out  # subsys_id
+        assert "rw[175:160] <= 16'h8086;" in out  # vend
+        assert "rw[191:176] <= 16'h1533;" in out  # dev
+        assert "rw[199:192] <= 8'h03;" in out     # rev
+
+    def test_preserves_anchor_comments(self):
+        out = patch_pcileech_fifo(ENIGMAX1_FIFO, _intel_donor())
+
+        for tag in (
+            "+010: CFG_SUBSYS_VEND_ID",
+            "+012: CFG_SUBSYS_ID",
+            "+014: CFG_VEND_ID",
+            "+016: CFG_DEV_ID",
+            "+018: CFG_REV_ID",
+        ):
+            assert tag in out, f"comment anchor {tag!r} lost during patch"
+
+    def test_rewrites_80bit_packed_initializer(self):
+        out = patch_pcileech_fifo(ENIGMAX1_FIFO, _intel_donor())
+
+        # Trailing 5 fields are rev, dev, vend, subsys_id, subsys_vend.
+        assert (
+            "{ 4'hf, 1'b1, 1'b1, 1'b0, 1'b0, 8'h03, 16'h1533, 16'h8086, 16'h0001, 16'h8086 }"
+            in out
+        )
+        assert "8'h02, 16'h0666, 16'h10EE, 16'h0007, 16'h10EE" not in out
+
+    def test_rewrites_78bit_packed_initializer(self):
+        out = patch_pcileech_fifo(NETV2_FIFO, _intel_donor())
+
+        assert (
+            "{ 1'b0, 1'b1, 1'b1, 1'b1, 1'b0, 1'b0, 8'h03, 16'h1533, 16'h8086, 16'h0001, 16'h8086 }"
+            in out
+        )
+        assert "16'h0666" not in out
+        assert "16'h10EE" not in out
+
+    def test_preserves_unrelated_lines(self):
+        out = patch_pcileech_fifo(ENIGMAX1_FIFO, _intel_donor())
+
+        # rw[200] sits below the patched block and must survive untouched.
+        assert "rw[200]     <= 1'b1;" in out
+        # Reset assigns that already work must be untouched.
+        assert "assign dpcie.pcie_rst_core    = _pcie_core_config[72];" in out
+
+    def test_xilinx_donor_yields_xilinx_defaults(self):
+        # Donor that happens to match Xilinx defaults should round-trip.
+        same = DonorIDs(
+            vendor_id=0x10EE,
+            device_id=0x0666,
+            subsystem_vendor_id=0x10EE,
+            subsystem_id=0x0007,
+            revision_id=0x02,
+        )
+        out = patch_pcileech_fifo(ENIGMAX1_FIFO, same)
+        assert out == ENIGMAX1_FIFO
+
+    def test_missing_anchor_raises(self):
+        # Strip the +014: CFG_VEND_ID line entirely — patcher must raise.
+        broken = re.sub(
+            r".*\+014: CFG_VEND_ID.*\n", "", ENIGMAX1_FIFO
+        )
+        with pytest.raises(FifoPatchError) as exc:
+            patch_pcileech_fifo(broken, _intel_donor())
+        assert "+014" in str(exc.value) or "CFG_VEND_ID" in str(exc.value)
+
+    def test_missing_initializer_raises(self):
+        broken = re.sub(
+            r"reg\s+\[\d+:0\]\s+_pcie_core_config\s*=.*?;\n",
+            "",
+            ENIGMAX1_FIFO,
+        )
+        with pytest.raises(FifoPatchError) as exc:
+            patch_pcileech_fifo(broken, _intel_donor())
+        assert "_pcie_core_config" in str(exc.value)
+
+    def test_donor_value_out_of_range_raises(self):
+        bad = DonorIDs(
+            vendor_id=0x8086,
+            device_id=0x1533,
+            subsystem_vendor_id=0x8086,
+            subsystem_id=0x0001,
+            revision_id=0x100,  # 9 bits — too wide for 8'h
+        )
+        with pytest.raises(FifoPatchError):
+            patch_pcileech_fifo(ENIGMAX1_FIFO, bad)
+
+
+# ---------------------------------------------------------------------------
+# Cfg-id assign comment-out branch (issue #593 symptom B)
+# ---------------------------------------------------------------------------
+
+
+class TestCfgIdAssignsCommentBranch:
+    """When the header lacks the cfg-id fields, comment out the assigns."""
+
+    def test_comments_out_when_header_missing_fields(self):
+        out = patch_pcileech_fifo(
+            CAPTAIN_75T_FIFO, _intel_donor(), header_text=HEADER_WITHOUT_CFG_FIELDS
+        )
+
+        for field in (
+            "pcie_cfg_subsys_vend_id",
+            "pcie_cfg_subsys_id",
+            "pcie_cfg_vend_id",
+            "pcie_cfg_dev_id",
+            "pcie_cfg_rev_id",
+        ):
+            assigns = [
+                line
+                for line in out.splitlines()
+                if f"dpcie.{field}" in line and "assign" in line
+            ]
+            assert assigns, f"missing line referencing {field}"
+            for line in assigns:
+                stripped = line.lstrip()
+                assert stripped.startswith("//"), (
+                    f"expected line to be commented out, got: {line!r}"
+                )
+
+        # Reset assigns must NOT be commented out.
+        rst_lines = [
+            line
+            for line in out.splitlines()
+            if "dpcie.pcie_rst_core" in line and "assign" in line
+        ]
+        assert rst_lines and not rst_lines[0].lstrip().startswith("//")
+
+    def test_keeps_assigns_when_header_declares_fields(self):
+        out = patch_pcileech_fifo(
+            CAPTAIN_75T_FIFO, _intel_donor(), header_text=HEADER_WITH_CFG_FIELDS
+        )
+
+        for field in (
+            "pcie_cfg_subsys_vend_id",
+            "pcie_cfg_subsys_id",
+            "pcie_cfg_vend_id",
+            "pcie_cfg_dev_id",
+            "pcie_cfg_rev_id",
+        ):
+            assigns = [
+                line
+                for line in out.splitlines()
+                if f"dpcie.{field}" in line and "assign" in line
+            ]
+            assert assigns
+            for line in assigns:
+                assert not line.lstrip().startswith("//"), (
+                    f"line should be left active, got: {line!r}"
+                )
+
+    def test_no_header_keeps_assigns(self):
+        # Backward-compatible default: no header passed → no commenting.
+        out = patch_pcileech_fifo(CAPTAIN_75T_FIFO, _intel_donor())
+        assigns = [
+            line
+            for line in out.splitlines()
+            if "dpcie.pcie_cfg_subsys_vend_id" in line and "assign" in line
+        ]
+        assert assigns and not assigns[0].lstrip().startswith("//")
+
+
+# ---------------------------------------------------------------------------
+# Filesystem orchestration: apply_fifo_donor_patch
+# ---------------------------------------------------------------------------
+
+
+class TestApplyFifoDonorPatch:
+    """apply_fifo_donor_patch reads from disk, patches in place, returns summary."""
+
+    def test_patches_files_in_place(self, tmp_path):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        fifo_path = src_dir / "pcileech_fifo.sv"
+        fifo_path.write_text(CAPTAIN_75T_FIFO)
+        header_path = src_dir / "pcileech_header.svh"
+        header_path.write_text(HEADER_WITHOUT_CFG_FIELDS)
+
+        result = apply_fifo_donor_patch(src_dir, _intel_donor())
+
+        assert result["patched"] is True
+        assert result["fifo_path"] == fifo_path
+        assert result["cfg_assigns_commented"] is True
+
+        patched = fifo_path.read_text()
+        assert "rw[175:160] <= 16'h8086;" in patched
+        # Cfg-id assigns commented out.
+        for field in (
+            "pcie_cfg_subsys_vend_id",
+            "pcie_cfg_subsys_id",
+            "pcie_cfg_vend_id",
+            "pcie_cfg_dev_id",
+            "pcie_cfg_rev_id",
+        ):
+            for line in patched.splitlines():
+                if f"dpcie.{field}" in line and "assign" in line:
+                    assert line.lstrip().startswith("//")
+
+    def test_skips_when_fifo_missing(self, tmp_path):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+
+        result = apply_fifo_donor_patch(src_dir, _intel_donor())
+
+        assert result["patched"] is False
+        assert result.get("reason") == "fifo_not_found"
+
+    def test_leaves_assigns_when_header_declares_fields(self, tmp_path):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (src_dir / "pcileech_fifo.sv").write_text(CAPTAIN_75T_FIFO)
+        (src_dir / "pcileech_header.svh").write_text(HEADER_WITH_CFG_FIELDS)
+
+        result = apply_fifo_donor_patch(src_dir, _intel_donor())
+
+        assert result["patched"] is True
+        assert result["cfg_assigns_commented"] is False
+
+    def test_propagates_patch_errors(self, tmp_path):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        # Strip the +016 anchor to trigger FifoPatchError from the inner pass.
+        (src_dir / "pcileech_fifo.sv").write_text(
+            re.sub(r".*\+016: CFG_DEV_ID.*\n", "", CAPTAIN_75T_FIFO)
+        )
+
+        with pytest.raises(FifoPatchError):
+            apply_fifo_donor_patch(src_dir, _intel_donor())
+
+
+# ---------------------------------------------------------------------------
+# Template-context adapter
+# ---------------------------------------------------------------------------
+
+
+class TestDonorIdsFromTemplateContext:
+    """Pull DonorIDs out of the build's template_context dict."""
+
+    def test_reads_int_suffixed_fields(self):
+        ctx = {
+            "device_config": {
+                "vendor_id_int": 0x8086,
+                "device_id_int": 0x1533,
+                "subsystem_vendor_id_int": 0x8086,
+                "subsystem_device_id_int": 0x0001,
+                "revision_id_int": 0x03,
+            }
+        }
+        donor = donor_ids_from_template_context(ctx)
+        assert donor == DonorIDs(0x8086, 0x1533, 0x8086, 0x0001, 0x03)
+
+    def test_falls_back_to_string_fields(self):
+        ctx = {
+            "device_config": {
+                "vendor_id": "0x8086",
+                "device_id": "0x1533",
+                "subsystem_vendor_id": "0x8086",
+                "subsystem_device_id": "0x0001",
+                "revision_id": "0x03",
+            }
+        }
+        donor = donor_ids_from_template_context(ctx)
+        assert donor == DonorIDs(0x8086, 0x1533, 0x8086, 0x0001, 0x03)
+
+    def test_returns_none_when_device_config_missing(self):
+        assert donor_ids_from_template_context({}) is None
+
+    def test_returns_none_when_required_field_zero(self):
+        # vendor_id=0 means we never recovered donor data — refuse to patch.
+        ctx = {
+            "device_config": {
+                "vendor_id_int": 0,
+                "device_id_int": 0x1533,
+                "subsystem_vendor_id_int": 0x8086,
+                "subsystem_device_id_int": 0x0001,
+                "revision_id_int": 0x03,
+            }
+        }
+        assert donor_ids_from_template_context(ctx) is None
+
+    def test_subsystem_zero_falls_back_to_main_vendor(self):
+        # Real devices often report subsystem IDs of 0; mirror the helper-macro
+        # behavior of falling back to the main vendor so the patch still produces
+        # a valid build.
+        ctx = {
+            "device_config": {
+                "vendor_id_int": 0x8086,
+                "device_id_int": 0x1533,
+                "subsystem_vendor_id_int": 0,
+                "subsystem_device_id_int": 0,
+                "revision_id_int": 0x03,
+            }
+        }
+        donor = donor_ids_from_template_context(ctx)
+        assert donor == DonorIDs(0x8086, 0x1533, 0x8086, 0x0000, 0x03)
+
+
+# ---------------------------------------------------------------------------
+# Build wiring: FirmwareBuilder._patch_fifo_with_donor_ids
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWiring:
+    """The build's _patch_fifo_with_donor_ids step calls into the patcher."""
+
+    def _make_builder(self, output_dir):
+        from pcileechfwgenerator.build import FirmwareBuilder
+
+        builder = FirmwareBuilder.__new__(FirmwareBuilder)
+        builder.config = type(
+            "C", (), {"output_dir": Path(output_dir), "board": "75t"}
+        )()
+        builder.logger = __import__("logging").getLogger("test")
+        return builder
+
+    def test_patches_when_donor_present(self, tmp_path):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (src_dir / "pcileech_fifo.sv").write_text(CAPTAIN_75T_FIFO)
+        (src_dir / "pcileech_header.svh").write_text(HEADER_WITHOUT_CFG_FIELDS)
+
+        builder = self._make_builder(tmp_path)
+        result = {
+            "template_context": {
+                "device_config": {
+                    "vendor_id_int": 0x8086,
+                    "device_id_int": 0x1533,
+                    "subsystem_vendor_id_int": 0x8086,
+                    "subsystem_device_id_int": 0x0001,
+                    "revision_id_int": 0x03,
+                }
+            }
+        }
+
+        builder._patch_fifo_with_donor_ids(result)
+
+        patched = (src_dir / "pcileech_fifo.sv").read_text()
+        assert "16'h8086" in patched
+        assert "16'h1533" in patched
+        # 75t484_x1-shaped fixture had cfg-id assigns; with header missing
+        # the fields, they must be commented after patching.
+        for line in patched.splitlines():
+            if "dpcie.pcie_cfg_subsys_vend_id" in line and "assign" in line:
+                assert line.lstrip().startswith("//")
+
+    def test_skips_silently_without_donor_data(self, tmp_path, caplog):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (src_dir / "pcileech_fifo.sv").write_text(ENIGMAX1_FIFO)
+
+        builder = self._make_builder(tmp_path)
+        # Empty template_context → no donor data → no patching, just a warning.
+        with caplog.at_level("WARNING"):
+            builder._patch_fifo_with_donor_ids({"template_context": {}})
+
+        assert (src_dir / "pcileech_fifo.sv").read_text() == ENIGMAX1_FIFO
+        assert any(
+            "issue #593" in rec.message or "donor" in rec.message.lower()
+            for rec in caplog.records
+        )
+
+    def test_raises_on_anchor_mismatch(self, tmp_path):
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (src_dir / "pcileech_fifo.sv").write_text(
+            re.sub(r".*\+010: CFG_SUBSYS_VEND_ID.*\n", "", ENIGMAX1_FIFO)
+        )
+
+        builder = self._make_builder(tmp_path)
+        result = {
+            "template_context": {
+                "device_config": {
+                    "vendor_id_int": 0x8086,
+                    "device_id_int": 0x1533,
+                    "subsystem_vendor_id_int": 0x8086,
+                    "subsystem_device_id_int": 0x0001,
+                    "revision_id_int": 0x03,
+                }
+            }
+        }
+        with pytest.raises(FifoPatchError):
+            builder._patch_fifo_with_donor_ids(result)

--- a/tests/test_fifo_donor_patcher.py
+++ b/tests/test_fifo_donor_patcher.py
@@ -304,7 +304,8 @@ class TestApplyFifoDonorPatch:
 
         result = apply_fifo_donor_patch(src_dir, _intel_donor())
 
-        assert result["patched"] is True
+        assert result["processed"] is True
+        assert result["changed"] is True
         assert result["fifo_path"] == fifo_path
         assert result["cfg_assigns_commented"] is True
 
@@ -328,7 +329,8 @@ class TestApplyFifoDonorPatch:
 
         result = apply_fifo_donor_patch(src_dir, _intel_donor())
 
-        assert result["patched"] is False
+        assert result["processed"] is False
+        assert result["changed"] is False
         assert result.get("reason") == "fifo_not_found"
 
     def test_leaves_assigns_when_header_declares_fields(self, tmp_path):
@@ -339,7 +341,7 @@ class TestApplyFifoDonorPatch:
 
         result = apply_fifo_donor_patch(src_dir, _intel_donor())
 
-        assert result["patched"] is True
+        assert result["processed"] is True
         assert result["cfg_assigns_commented"] is False
 
     def test_raises_on_unpatchable_unknown_field(self, tmp_path):
@@ -379,7 +381,29 @@ class TestApplyFifoDonorPatch:
         )
 
         result = apply_fifo_donor_patch(src_dir, _intel_donor())
-        assert result["patched"] is True
+        assert result["processed"] is True
+
+    def test_xilinx_donor_does_not_rewrite_file(self, tmp_path):
+        # Round-trip case: donor IDs match upstream Xilinx defaults, so the
+        # patch is a no-op. processed=True (we ran the pipeline) but
+        # changed=False (file untouched on disk).
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (src_dir / "pcileech_fifo.sv").write_text(ENIGMAX1_FIFO)
+        same = DonorIDs(
+            vendor_id=0x10EE,
+            device_id=0x0666,
+            subsystem_vendor_id=0x10EE,
+            subsystem_id=0x0007,
+            revision_id=0x02,
+        )
+        mtime_before = (src_dir / "pcileech_fifo.sv").stat().st_mtime_ns
+        result = apply_fifo_donor_patch(src_dir, same)
+        mtime_after = (src_dir / "pcileech_fifo.sv").stat().st_mtime_ns
+
+        assert result["processed"] is True
+        assert result["changed"] is False
+        assert mtime_before == mtime_after
 
     def test_propagates_patch_errors(self, tmp_path):
         src_dir = tmp_path / "src"
@@ -469,13 +493,20 @@ class TestBuildWiring:
     """The build's _patch_fifo_with_donor_ids step calls into the patcher."""
 
     def _make_builder(self, output_dir):
-        # Some other tests in the suite stub `pcileechfwgenerator.build`
-        # via sys.modules and never restore it. Force a real reimport so
-        # FirmwareBuilder resolves regardless of test ordering.
+        # Some other tests stub `pcileechfwgenerator.build` via sys.modules
+        # (test_container_unit, test_orchestration_local) and never restore it.
+        # Force a reimport only when the cached FirmwareBuilder is missing
+        # the method under test — popping an already-loaded real module would
+        # invalidate other tests' patches against it.
         import importlib
         import sys as _sys
-        _sys.modules.pop("pcileechfwgenerator.build", None)
-        build_module = importlib.import_module("pcileechfwgenerator.build")
+        cached = _sys.modules.get("pcileechfwgenerator.build")
+        builder_cls = getattr(cached, "FirmwareBuilder", None)
+        if builder_cls is None or not hasattr(builder_cls, "_patch_fifo_with_donor_ids"):
+            _sys.modules.pop("pcileechfwgenerator.build", None)
+            build_module = importlib.import_module("pcileechfwgenerator.build")
+        else:
+            build_module = cached
         FirmwareBuilder = build_module.FirmwareBuilder
 
         builder = FirmwareBuilder.__new__(FirmwareBuilder)

--- a/tests/test_fifo_donor_patcher.py
+++ b/tests/test_fifo_donor_patcher.py
@@ -342,6 +342,45 @@ class TestApplyFifoDonorPatch:
         assert result["patched"] is True
         assert result["cfg_assigns_commented"] is False
 
+    def test_raises_on_unpatchable_unknown_field(self, tmp_path):
+        # A fifo that writes to an interface field neither in the header nor
+        # in the patcher's known set of "comment me out" fields. Patcher must
+        # not silently leave the broken assign — raise so the build aborts
+        # before Vivado does.
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        rogue_fifo = CAPTAIN_75T_FIFO + textwrap.dedent(
+            """
+            assign dpcie.totally_made_up_field = 1'b0;
+            """
+        )
+        (src_dir / "pcileech_fifo.sv").write_text(rogue_fifo)
+        (src_dir / "pcileech_header.svh").write_text(HEADER_WITHOUT_CFG_FIELDS)
+
+        with pytest.raises(FifoPatchError) as exc:
+            apply_fifo_donor_patch(src_dir, _intel_donor())
+        assert "totally_made_up_field" in str(exc.value)
+
+    def test_unknown_field_passes_when_declared_in_header(self, tmp_path):
+        # Same rogue field, but the header declares it — no error.
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        rogue_fifo = CAPTAIN_75T_FIFO + textwrap.dedent(
+            """
+            assign dpcie.totally_made_up_field = 1'b0;
+            """
+        )
+        (src_dir / "pcileech_fifo.sv").write_text(rogue_fifo)
+        (src_dir / "pcileech_header.svh").write_text(
+            HEADER_WITH_CFG_FIELDS.replace(
+                "endinterface",
+                "    wire totally_made_up_field;\nendinterface",
+            )
+        )
+
+        result = apply_fifo_donor_patch(src_dir, _intel_donor())
+        assert result["patched"] is True
+
     def test_propagates_patch_errors(self, tmp_path):
         src_dir = tmp_path / "src"
         src_dir.mkdir()

--- a/tests/test_fifo_donor_patcher.py
+++ b/tests/test_fifo_donor_patcher.py
@@ -469,7 +469,14 @@ class TestBuildWiring:
     """The build's _patch_fifo_with_donor_ids step calls into the patcher."""
 
     def _make_builder(self, output_dir):
-        from pcileechfwgenerator.build import FirmwareBuilder
+        # Some other tests in the suite stub `pcileechfwgenerator.build`
+        # via sys.modules and never restore it. Force a real reimport so
+        # FirmwareBuilder resolves regardless of test ordering.
+        import importlib
+        import sys as _sys
+        _sys.modules.pop("pcileechfwgenerator.build", None)
+        build_module = importlib.import_module("pcileechfwgenerator.build")
+        FirmwareBuilder = build_module.FirmwareBuilder
 
         builder = FirmwareBuilder.__new__(FirmwareBuilder)
         builder.config = type(

--- a/tests/test_pcie_ip_donor_override.py
+++ b/tests/test_pcie_ip_donor_override.py
@@ -173,7 +173,14 @@ class TestBuildWiringIpOverride:
     """FirmwareBuilder._patch_fifo_with_donor_ids also wires the IP override."""
 
     def _make_builder(self, output_dir):
-        from pcileechfwgenerator.build import FirmwareBuilder
+        # Some other tests in the suite stub `pcileechfwgenerator.build`
+        # via sys.modules and never restore it. Force a real reimport so
+        # FirmwareBuilder resolves regardless of test ordering.
+        import importlib
+        import sys as _sys
+        _sys.modules.pop("pcileechfwgenerator.build", None)
+        build_module = importlib.import_module("pcileechfwgenerator.build")
+        FirmwareBuilder = build_module.FirmwareBuilder
 
         builder = FirmwareBuilder.__new__(FirmwareBuilder)
         builder.config = type(

--- a/tests/test_pcie_ip_donor_override.py
+++ b/tests/test_pcie_ip_donor_override.py
@@ -1,0 +1,246 @@
+"""Tests for PCIe IP donor-ID override TCL emission (issue #593, T2).
+
+Donor IDs need to override the Vivado PCIe 7-series IP's CONFIG properties so
+the host sees donor vendor/device/subsys/rev during enumeration. The upstream
+``vivado_generate_project_*.tcl`` imports ``pcie_7x_0.xci`` verbatim with its
+Xilinx defaults (``Vendor_ID=10EE``, ``Device_ID=0666``, etc.). These helpers
+emit a TCL fragment that runs after the IP is imported and patches its CONFIG.
+"""
+import re
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent.resolve()
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from pcileechfwgenerator.vivado_handling.fifo_donor_patcher import DonorIDs
+from pcileechfwgenerator.vivado_handling.pcie_ip_donor_override import (
+    PcieIpOverrideError,
+    apply_pcie_ip_donor_override,
+    generate_pcie_ip_override_tcl,
+)
+
+
+def _intel_donor() -> DonorIDs:
+    return DonorIDs(
+        vendor_id=0x8086,
+        device_id=0x1533,
+        subsystem_vendor_id=0x8086,
+        subsystem_id=0x0001,
+        revision_id=0x03,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure TCL emission
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratePcieIpOverrideTcl:
+    """generate_pcie_ip_override_tcl renders a Vivado set_property block."""
+
+    def test_emits_all_five_config_properties(self):
+        tcl = generate_pcie_ip_override_tcl(_intel_donor())
+
+        # Vivado property names are case-sensitive; assert exact spellings.
+        assert "CONFIG.Vendor_ID 0x8086" in tcl
+        assert "CONFIG.Device_ID 0x1533" in tcl
+        assert "CONFIG.Subsystem_Vendor_ID 0x8086" in tcl
+        assert "CONFIG.Subsystem_ID 0x0001" in tcl
+        assert "CONFIG.Revision_ID 0x03" in tcl
+
+    def test_targets_pcie_7x_0_by_default(self):
+        tcl = generate_pcie_ip_override_tcl(_intel_donor())
+        assert "[get_ips pcie_7x_0]" in tcl
+
+    def test_accepts_custom_ip_name(self):
+        tcl = generate_pcie_ip_override_tcl(_intel_donor(), ip_name="pcie_us_0")
+        assert "[get_ips pcie_us_0]" in tcl
+        assert "[get_ips pcie_7x_0]" not in tcl
+
+    def test_regenerates_target_after_property_change(self):
+        # Without generate_target the CONFIG change won't propagate to the
+        # generated HDL — IP must be re-generated after override.
+        tcl = generate_pcie_ip_override_tcl(_intel_donor())
+        assert "generate_target" in tcl
+        assert re.search(r"generate_target.*\[get_ips pcie_7x_0\]", tcl)
+
+    def test_skips_silently_when_ip_absent(self):
+        # If the IP can't be found (e.g. running on a board variant that
+        # ships a different PCIe IP), the script must not abort the build.
+        tcl = generate_pcie_ip_override_tcl(_intel_donor())
+        assert "if {" in tcl  # guarded by an existence check
+        assert "[llength" in tcl or "[get_ips -quiet" in tcl
+
+    def test_balanced_braces(self):
+        tcl = generate_pcie_ip_override_tcl(_intel_donor())
+        # Balanced braces are a basic well-formedness check; Vivado will
+        # otherwise abort with a generic syntax error.
+        assert tcl.count("{") == tcl.count("}")
+        assert tcl.count("[") == tcl.count("]")
+
+    def test_includes_issue_marker(self):
+        # Future debuggers should be able to grep for the origin of this code.
+        tcl = generate_pcie_ip_override_tcl(_intel_donor())
+        assert "#593" in tcl or "issue 593" in tcl.lower()
+
+
+# ---------------------------------------------------------------------------
+# Filesystem orchestration
+# ---------------------------------------------------------------------------
+
+
+_FAKE_GENERATE_PROJECT = textwrap.dedent(
+    """\
+    # Upstream vivado_generate_project_captaindma_75t.tcl (truncated)
+    create_project pcileech ./vivado_project -part xc7a75tfgg484-2
+
+    # Import IP
+    set files [list \\
+     [file normalize "${origin_dir}/ip/pcie_7x_0.xci"]\\
+    ]
+    import_files -fileset sources_1 $files
+    """
+)
+
+
+class TestApplyPcieIpDonorOverride:
+    """apply_pcie_ip_donor_override writes the override and wires it in."""
+
+    def test_writes_override_file_and_appends_source(self, tmp_path):
+        (tmp_path / "vivado_generate_project_captaindma_75t.tcl").write_text(
+            _FAKE_GENERATE_PROJECT
+        )
+
+        result = apply_pcie_ip_donor_override(tmp_path, _intel_donor())
+
+        assert result["override_path"].name == "pcileech_donor_ip_overrides.tcl"
+        assert result["override_path"].is_file()
+
+        override = result["override_path"].read_text()
+        assert "CONFIG.Vendor_ID 0x8086" in override
+
+        # The upstream generate-project script must source our override.
+        gp = (tmp_path / "vivado_generate_project_captaindma_75t.tcl").read_text()
+        assert "source" in gp
+        assert "pcileech_donor_ip_overrides.tcl" in gp
+
+    def test_idempotent(self, tmp_path):
+        (tmp_path / "vivado_generate_project.tcl").write_text(_FAKE_GENERATE_PROJECT)
+
+        apply_pcie_ip_donor_override(tmp_path, _intel_donor())
+        before = (tmp_path / "vivado_generate_project.tcl").read_text()
+
+        apply_pcie_ip_donor_override(tmp_path, _intel_donor())
+        after = (tmp_path / "vivado_generate_project.tcl").read_text()
+
+        # Source line appended exactly once even on a second application.
+        assert before == after
+        assert after.count("pcileech_donor_ip_overrides.tcl") == 1
+
+    def test_raises_when_no_generate_project_script(self, tmp_path):
+        # No vivado_generate_project*.tcl staged — caller's mistake, fail loud.
+        with pytest.raises(PcieIpOverrideError) as exc:
+            apply_pcie_ip_donor_override(tmp_path, _intel_donor())
+        assert "vivado_generate_project" in str(exc.value)
+
+    def test_picks_first_matching_script(self, tmp_path):
+        # Some boards ship multiple variants (e.g. _35t and _100t); pick the
+        # first deterministically and wire into it.
+        (tmp_path / "vivado_generate_project_35t.tcl").write_text(_FAKE_GENERATE_PROJECT)
+        (tmp_path / "vivado_generate_project_100t.tcl").write_text(_FAKE_GENERATE_PROJECT)
+
+        result = apply_pcie_ip_donor_override(tmp_path, _intel_donor())
+
+        # Both should get the source line — applying overrides to whichever
+        # script Vivado ends up calling is safer than guessing.
+        for name in ("vivado_generate_project_35t.tcl", "vivado_generate_project_100t.tcl"):
+            assert "pcileech_donor_ip_overrides.tcl" in (tmp_path / name).read_text()
+
+        assert result["override_path"].is_file()
+
+
+# ---------------------------------------------------------------------------
+# Build wiring
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWiringIpOverride:
+    """FirmwareBuilder._patch_fifo_with_donor_ids also wires the IP override."""
+
+    def _make_builder(self, output_dir):
+        from pcileechfwgenerator.build import FirmwareBuilder
+
+        builder = FirmwareBuilder.__new__(FirmwareBuilder)
+        builder.config = type(
+            "C", (), {"output_dir": Path(output_dir), "board": "75t"}
+        )()
+        builder.logger = __import__("logging").getLogger("test")
+        return builder
+
+    def test_writes_override_and_wires_source(self, tmp_path):
+        # FIFO present so the existing patch step doesn't return early.
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        from tests.test_fifo_donor_patcher import (  # noqa: PLC0415
+            ENIGMAX1_FIFO,
+        )
+        (src_dir / "pcileech_fifo.sv").write_text(ENIGMAX1_FIFO)
+        (tmp_path / "vivado_generate_project.tcl").write_text(
+            _FAKE_GENERATE_PROJECT
+        )
+
+        builder = self._make_builder(tmp_path)
+        result = {
+            "template_context": {
+                "device_config": {
+                    "vendor_id_int": 0x8086,
+                    "device_id_int": 0x1533,
+                    "subsystem_vendor_id_int": 0x8086,
+                    "subsystem_device_id_int": 0x0001,
+                    "revision_id_int": 0x03,
+                }
+            }
+        }
+        builder._patch_fifo_with_donor_ids(result)
+
+        override = tmp_path / "pcileech_donor_ip_overrides.tcl"
+        assert override.is_file()
+        assert "CONFIG.Vendor_ID 0x8086" in override.read_text()
+
+        gp = (tmp_path / "vivado_generate_project.tcl").read_text()
+        assert "pcileech_donor_ip_overrides.tcl" in gp
+
+    def test_warns_when_no_generate_project_script(self, tmp_path, caplog):
+        # FIFO patch can run, but the IP override step must not break the
+        # build when the generate-project script hasn't been staged yet.
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        from tests.test_fifo_donor_patcher import (  # noqa: PLC0415
+            ENIGMAX1_FIFO,
+        )
+        (src_dir / "pcileech_fifo.sv").write_text(ENIGMAX1_FIFO)
+
+        builder = self._make_builder(tmp_path)
+        result = {
+            "template_context": {
+                "device_config": {
+                    "vendor_id_int": 0x8086,
+                    "device_id_int": 0x1533,
+                    "subsystem_vendor_id_int": 0x8086,
+                    "subsystem_device_id_int": 0x0001,
+                    "revision_id_int": 0x03,
+                }
+            }
+        }
+        with caplog.at_level("WARNING"):
+            builder._patch_fifo_with_donor_ids(result)
+
+        assert any(
+            "PCIe IP donor override skipped" in rec.message
+            for rec in caplog.records
+        )

--- a/tests/test_pcie_ip_donor_override.py
+++ b/tests/test_pcie_ip_donor_override.py
@@ -148,20 +148,20 @@ class TestApplyPcieIpDonorOverride:
             apply_pcie_ip_donor_override(tmp_path, _intel_donor())
         assert "vivado_generate_project" in str(exc.value)
 
-    def test_picks_first_matching_script(self, tmp_path):
-        # Some boards ship multiple variants (e.g. _35t and _100t); pick the
-        # first deterministically and wire into it.
+    def test_wires_into_all_matching_scripts(self, tmp_path):
+        # Some boards ship multiple variants (e.g. _35t and _100t). We can't
+        # know which one vivado_build.tcl will actually source, so wire the
+        # override into every match instead of guessing.
         (tmp_path / "vivado_generate_project_35t.tcl").write_text(_FAKE_GENERATE_PROJECT)
         (tmp_path / "vivado_generate_project_100t.tcl").write_text(_FAKE_GENERATE_PROJECT)
 
         result = apply_pcie_ip_donor_override(tmp_path, _intel_donor())
 
-        # Both should get the source line — applying overrides to whichever
-        # script Vivado ends up calling is safer than guessing.
         for name in ("vivado_generate_project_35t.tcl", "vivado_generate_project_100t.tcl"):
             assert "pcileech_donor_ip_overrides.tcl" in (tmp_path / name).read_text()
 
         assert result["override_path"].is_file()
+        assert len(result["wired_scripts"]) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -173,13 +173,20 @@ class TestBuildWiringIpOverride:
     """FirmwareBuilder._patch_fifo_with_donor_ids also wires the IP override."""
 
     def _make_builder(self, output_dir):
-        # Some other tests in the suite stub `pcileechfwgenerator.build`
-        # via sys.modules and never restore it. Force a real reimport so
-        # FirmwareBuilder resolves regardless of test ordering.
+        # Some other tests stub `pcileechfwgenerator.build` via sys.modules
+        # (test_container_unit, test_orchestration_local) and never restore it.
+        # Force a reimport only when the cached FirmwareBuilder is missing
+        # the method under test — popping an already-loaded real module would
+        # invalidate other tests' patches against it.
         import importlib
         import sys as _sys
-        _sys.modules.pop("pcileechfwgenerator.build", None)
-        build_module = importlib.import_module("pcileechfwgenerator.build")
+        cached = _sys.modules.get("pcileechfwgenerator.build")
+        builder_cls = getattr(cached, "FirmwareBuilder", None)
+        if builder_cls is None or not hasattr(builder_cls, "_patch_fifo_with_donor_ids"):
+            _sys.modules.pop("pcileechfwgenerator.build", None)
+            build_module = importlib.import_module("pcileechfwgenerator.build")
+        else:
+            build_module = cached
         FirmwareBuilder = build_module.FirmwareBuilder
 
         builder = FirmwareBuilder.__new__(FirmwareBuilder)


### PR DESCRIPTION
Closes #593.

## Summary

- **Symptom A** (`75t`): build succeeded but `pcileech_fifo.sv` still carried Xilinx defaults (`16'h10EE` vendor, `16'h0666` device, `8'h02` rev) — donor IDs only landed in the cfgspace shadow, never in the FIFO's RW reset block or in the Vivado PCIe IP block itself.
- **Symptom B** (`pcileech_75t484_x1`): synthesis aborted with `cannot resolve hierarchical name for the item 'pcie_cfg_subsys_vend_id'` because the upstream CaptainDMA/75t484_x1 `pcileech_fifo.sv` writes to `IfPCIeFifoCore` fields its own `pcileech_header.svh` doesn't declare.

Both fixes happen post-copy on the staged sources — `lib/voltcyclone-fpga` stays untouched (it's a submodule).

## What changed

1. **`fifo_donor_patcher`** rewrites the FIFO's RW reset block (`+010` ... `+018` anchors) and the `_pcie_core_config` packed initializer with donor IDs. Handles both the 80-bit (CaptainDMA/EnigmaX1) and 78-bit (NeTV2/pciescreamer) variants. Comments out `assign dpcie.pcie_cfg_*` lines when the staged header doesn't declare those interface fields.
2. **`pcie_ip_donor_override`** emits `pcileech_donor_ip_overrides.tcl` with `set_property -dict CONFIG.Vendor_ID/Device_ID/Subsystem_Vendor_ID/Subsystem_ID/Revision_ID` + `generate_target`, and appends an idempotent `source` line to every staged `vivado_generate_project*.tcl`. Guarded by `[get_ips -quiet pcie_7x_0]` so non-A7 boards don't abort.
3. **Validator** raises `FifoPatchError` when the staged FIFO writes to any other `dpcie.<field>` not declared in the staged header (and not handled by the comment-out branch). Surfaces the inconsistency before Vivado runs instead of after a multi-minute synthesis.
4. **Build log** warns once per build, naming the board, when cfg-id assigns are commented — explains that donor IDs still flow via the cfgspace shadow + IP CONFIG override.
5. **Smoke regression tests** for `75t` and `pcileech_75t484_x1` drive the production `FileManager` + patcher pipeline against the real submodule. They're the canary for upstream drift.

## Coverage

Validated against all 14 upstream board variants under `lib/voltcyclone-fpga/`:
- 11 boards correctly get cfg-id assigns commented (header doesn't declare)
- 3 boards (NeTV2, acorn_ft2232h, pciescreamer) leave assigns active (header declares)
- 0 boards have unpatchable `dpcie.<unknown>` mismatches

## Out of scope (filed for follow-up)

- Patching `lib/voltcyclone-fpga/CaptainDMA/{75t484_x1,100t484-1,...}/src/pcileech_header.svh` to declare the cfg-id interface fields is the durable fix and belongs upstream. Worth filing a voltcyclone-fpga issue once this lands.
- Runtime support for the upstream `(NOT IMPLEMENTED)` RW slots so software can rewrite vendor/device IDs on the fly — feature work, not a bug fix.

## Test plan

- [x] `pytest tests/test_fifo_donor_patcher.py tests/test_pcie_ip_donor_override.py tests/test_board_source_generation.py` (53 new tests, all green)
- [x] Full suite minus e2e: 2358 passed, 40 skipped, 0 failed
- [x] Smoke-tested patcher + IP override against all 14 upstream board variants
- [ ] Manual build for `75t` against a non-Xilinx donor; confirm staged `pcileech_fifo.sv` reflects donor IDs and `pcileech_donor_ip_overrides.tcl` is sourced from the generate-project script
- [ ] Manual build for `pcileech_75t484_x1` runs through Vivado synthesis without `cannot resolve hierarchical name` errors

Plan: `docs/plans/issue-593-xilinx-defaults-fifo.md`.