### PR TITLE
TUI correctness pass — 14 bug fixes (T1–T14)

### DIFF
--- a/src/tui/core/app_state.py
+++ b/src/tui/core/app_state.py
@@ -50,15 +50,22 @@ class AppState:
         """
         Update the state with the provided values.
 
+        Subscribers receive shallow *copies* of the old and new state so that
+        a re-entrant update (or an accidental in-place mutation in a
+        subscriber) cannot corrupt the live store mid-iteration. Subscribers
+        MUST treat both arguments as read-only.
+
         Args:
             updates: Dictionary of state updates to apply
         """
         old_state = self._state.copy()
         self._state.update(updates)
+        new_snapshot = self._state.copy()
 
-        # Notify subscribers of changes
-        for callback in self._subscribers:
-            callback(old_state, self._state)
+        # Iterate a copy of subscribers so a callback that unsubscribes
+        # itself doesn't skip the next one.
+        for callback in list(self._subscribers):
+            callback(old_state, new_snapshot)
 
     def get_state(self, key: Optional[str] = None) -> Any:
         """

--- a/src/tui/core/background_monitor.py
+++ b/src/tui/core/background_monitor.py
@@ -122,20 +122,22 @@ class BackgroundMonitor:
         """
         while self._running:
             try:
-                # Check for device changes
-                has_changes = await self.app.device_manager.check_for_changes()
+                devices = await self.app.device_manager.scan_devices()
+                signature = tuple(
+                    (d.bdf, d.driver, d.is_suitable) for d in devices
+                )
 
-                if has_changes:
-                    # Only update if devices have changed
-                    devices = await self.app.device_manager.get_devices()
+                if signature != self._last_status.get("devices_signature"):
+                    self._last_status["devices_signature"] = signature
 
-                    # Store current filtered devices
-                    self.app._devices = devices
-
-                    # Apply filters and update UI
+                    self.app.app_state.set_devices(devices)
                     self.app.ui_coordinator.apply_device_filters()
                     self.app.ui_coordinator.update_device_table()
-                    logger.debug("Device list updated due to changes")
+                    self.app.ui_coordinator._update_device_panel_title()
+                    logger.debug(
+                        "Device list updated due to changes (%d devices)",
+                        len(devices),
+                    )
             except Exception as e:
                 # Handle error without stopping the monitoring task
                 logger.error(f"Error monitoring device changes: {e}")

--- a/src/tui/core/background_monitor.py
+++ b/src/tui/core/background_monitor.py
@@ -123,8 +123,22 @@ class BackgroundMonitor:
         while self._running:
             try:
                 devices = await self.app.device_manager.scan_devices()
+                # Signature covers every field that influences a rendered row
+                # in VirtualDeviceTable._add_device_row plus stable identity.
+                # Updates to vendor/device names, IOMMU group, score, or the
+                # status indicator must trigger a re-render.
                 signature = tuple(
-                    (d.bdf, d.driver, d.is_suitable) for d in devices
+                    (
+                        d.bdf,
+                        getattr(d, "driver", None),
+                        getattr(d, "is_suitable", None),
+                        getattr(d, "vendor_name", None),
+                        getattr(d, "device_name", None),
+                        getattr(d, "iommu_group", None),
+                        round(float(getattr(d, "suitability_score", 0.0)), 4),
+                        getattr(d, "status_indicator", None),
+                    )
+                    for d in devices
                 )
 
                 if signature != self._last_status.get("devices_signature"):

--- a/src/tui/core/build_orchestrator.py
+++ b/src/tui/core/build_orchestrator.py
@@ -8,6 +8,7 @@ import asyncio
 import datetime
 import logging
 import os
+import shlex
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -859,7 +860,9 @@ class BuildOrchestrator:
             RuntimeError: If command fails
         """
         if isinstance(cmd, list):
-            cmd_str = " ".join(cmd)
+            # shlex.join quotes args that contain spaces so paths and other
+            # spaced values survive create_subprocess_shell's reparse.
+            cmd_str = shlex.join(cmd)
         else:
             cmd_str = cmd
 
@@ -1276,48 +1279,46 @@ class BuildOrchestrator:
             "skip_board_check": bool(config.skip_board_check),
         }
 
-        # Build command parts
-        build_cmd_parts = [
-            f"python3 src/build.py --bdf {device.bdf} --board {config.board_type}"
+        # Build the command as a list[str] from the start — strings with
+        # embedded spaces (paths, multi-word args) survive intact this way.
+        # Common build args (everything after the script name):
+        build_args: List[str] = [
+            "--bdf",
+            device.bdf,
+            "--board",
+            config.board_type,
         ]
-
         if cli_args.get("advanced_sv"):
-            build_cmd_parts.append("--advanced-sv")
+            build_args.append("--advanced-sv")
         if cli_args.get("enable_variance"):
-            build_cmd_parts.append("--enable-variance")
+            build_args.append("--enable-variance")
         if cli_args.get("enable_behavior_profiling"):
-            build_cmd_parts.append("--enable-behavior-profiling")
-            build_cmd_parts.append(
-                f"--profile-duration {cli_args['behavior_profile_duration']}"
+            build_args.extend(
+                [
+                    "--enable-behavior-profiling",
+                    "--profile-duration",
+                    str(cli_args["behavior_profile_duration"]),
+                ]
             )
-
-        # Add donor dump options
         if cli_args.get("use_donor_dump"):
-            build_cmd_parts.append("--use-donor-dump")
-        # Only add donor_info_file when explicitly provided and not empty
+            build_args.append("--use-donor-dump")
         donor_info_file = cli_args.get("donor_info_file")
         if (
             donor_info_file
             and isinstance(donor_info_file, str)
             and donor_info_file.strip()
         ):
-            build_cmd_parts.append(f"--donor-info-file {donor_info_file}")
+            build_args.extend(["--donor-info-file", donor_info_file])
         if cli_args.get("skip_board_check"):
-            build_cmd_parts.append("--skip-board-check")
-
-        # Add Vivado execution flag to actually run Vivado
-        build_cmd_parts.append("--run-vivado")
-
-        build_cmd = " ".join(build_cmd_parts)
+            build_args.append("--skip-board-check")
+        build_args.append("--run-vivado")
 
         if config.local_build:
-            # Run locally
             if self._current_progress:
                 self._current_progress.current_operation = "Running local build"
                 await self._notify_progress()
 
-            # Run the build command directly
-            await self._run_shell(build_cmd.split())
+            await self._run_shell(["python3", "src/build.py", *build_args])
         else:
             # Get IOMMU group for VFIO device
             from ...cli.vfio_handler import _get_iommu_group
@@ -1327,8 +1328,7 @@ class BuildOrchestrator:
             )
             vfio_device = f"/dev/vfio/{iommu_group}"
 
-            # Construct container command
-            container_cmd = [
+            container_cmd: List[str] = [
                 "podman",
                 "run",
                 "--rm",
@@ -1339,19 +1339,11 @@ class BuildOrchestrator:
                 "-v",
                 f"{os.getcwd()}/output:/app/output",
                 "pcileechfwgenerator:latest",
-                (
-                    f"python3 /app/src/build.py --bdf {device.bdf} "
-                    f"--board {config.board_type}"
-                ),
+                "python3",
+                "/app/src/build.py",
+                *build_args,
             ]
 
-            # Add the same options to the container command
-            for option in build_cmd_parts[
-                1:
-            ]:  # Skip the first part (python3 src/build.py)
-                container_cmd.append(option)
-
-            # Run container with progress monitoring
             await self._run_shell(container_cmd)
 
     async def _generate_bitstream(self, config: BuildConfiguration) -> None:

--- a/src/tui/core/build_orchestrator.py
+++ b/src/tui/core/build_orchestrator.py
@@ -80,7 +80,10 @@ class BuildOrchestrator:
         self._progress_callback: Optional[Callable[[BuildProgress], None]] = None
         self._is_building = False
         self._should_cancel = False
-        self._executor = ThreadPoolExecutor(max_workers=4)
+        # Executor is build-scoped: created at the top of start_build,
+        # shutdown in its finally. A late _update_resource_usage tick after
+        # shutdown must be a no-op, not a RuntimeError.
+        self._executor: Optional[ThreadPoolExecutor] = None
         self._last_resource_update = 0
         self._config: Optional[BuildConfiguration] = None
 
@@ -173,6 +176,7 @@ class BuildOrchestrator:
         self._should_cancel = False
         self._progress_callback = progress_callback
         self._config = config
+        self._executor = ThreadPoolExecutor(max_workers=4)
 
         # Initialize progress tracking
         self._current_progress = BuildProgress(
@@ -206,7 +210,10 @@ class BuildOrchestrator:
             raise
         finally:
             self._is_building = False
-            self._executor.shutdown(wait=True)
+            executor = self._executor
+            self._executor = None
+            if executor is not None:
+                executor.shutdown(wait=True)
 
     def _create_build_stages(
         self, device: PCIDevice, config: BuildConfiguration
@@ -407,9 +414,10 @@ class BuildOrchestrator:
         """
         Update system resource usage metrics in the progress state.
 
-        Collects CPU, memory, and disk usage information.
+        Collects CPU, memory, and disk usage information. A late tick after
+        the build's executor has been shut down is a graceful no-op.
         """
-        if not self._current_progress:
+        if not self._current_progress or self._executor is None:
             return
 
         try:

--- a/src/tui/core/build_orchestrator.py
+++ b/src/tui/core/build_orchestrator.py
@@ -35,6 +35,9 @@ RESOURCE_MONITOR_INTERVAL = 1.0  # Seconds between resource usage updates
 PROCESS_TERMINATION_TIMEOUT = 2.0  # Seconds to wait for process termination
 
 # Progress parsing tokens for easier maintenance
+READLINE_TIMEOUT_SEC = 1.0  # readline polling cadence in _run_shell
+
+
 LOG_PROGRESS_TOKENS = {
     "Running synthesis": (
         BuildStage.VIVADO_SYNTHESIS,
@@ -869,42 +872,90 @@ class BuildOrchestrator:
                 stderr=stderr.decode("utf-8"),
             )
 
-        # Monitored command execution
+        # Monitored command execution — drain stdout and stderr concurrently
+        # with a short readline timeout so we can poll _should_cancel even
+        # when a grandchild (Vivado) keeps the pipe open indefinitely.
         self._build_process = await asyncio.create_subprocess_shell(
             cmd_str,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
 
-        # Monitor process output for progress updates
-        while True:
-            if self._build_process.stdout:
-                line = await self._build_process.stdout.readline()
+        stderr_chunks: List[bytes] = []
+
+        async def _drain(stream, sink: Optional[List[bytes]]) -> None:
+            """Read one stream until EOF or cancel, never blocking forever."""
+            if stream is None:
+                return
+            while True:
+                try:
+                    line = await asyncio.wait_for(
+                        stream.readline(), timeout=READLINE_TIMEOUT_SEC
+                    )
+                except asyncio.TimeoutError:
+                    # Pipe is idle. Bail if we've been cancelled or the
+                    # process has exited and the pipe is closed.
+                    if self._should_cancel:
+                        return
+                    if self._build_process.returncode is not None:
+                        return
+                    continue
+
                 if not line:
+                    return
+
+                if sink is not None:
+                    sink.append(line)
+
+                # Only stdout drives progress updates.
+                if sink is None:
+                    line_str = line.decode("utf-8", errors="replace").strip()
+                    if line_str:
+                        for pattern, (stage, percent, msg) in LOG_PROGRESS_TOKENS.items():
+                            if pattern in line_str:
+                                await self._update_progress(stage, percent, msg)
+                                break
+
+        stdout_task = asyncio.create_task(_drain(self._build_process.stdout, None))
+        stderr_task = asyncio.create_task(_drain(self._build_process.stderr, stderr_chunks))
+
+        try:
+            while True:
+                if self._should_cancel:
+                    self._build_process.terminate()
+                    try:
+                        await asyncio.wait_for(self._build_process.wait(), timeout=2.0)
+                    except asyncio.TimeoutError:
+                        self._build_process.kill()
+                        await self._build_process.wait()
                     break
 
-                line_str = line.decode("utf-8").strip()
-                if line_str:
-                    # Update progress based on output using LOG_PROGRESS_TOKENS
-                    for pattern, (stage, percent, msg) in LOG_PROGRESS_TOKENS.items():
-                        if pattern in line_str:
-                            await self._update_progress(stage, percent, msg)
-                            break
+                if self._build_process.returncode is not None:
+                    break
 
-            # Check if process has completed
-            if self._build_process.returncode is not None:
-                break
+                try:
+                    await asyncio.wait_for(
+                        self._build_process.wait(), timeout=READLINE_TIMEOUT_SEC
+                    )
+                except asyncio.TimeoutError:
+                    continue
+        finally:
+            # Ensure both drain tasks finish before we read stderr_chunks.
+            for task in (stdout_task, stderr_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
 
-            await asyncio.sleep(0.1)
-
-        # Wait for process to complete
-        await self._build_process.wait()
+        if self._should_cancel:
+            return subprocess.CompletedProcess(
+                args=cmd_str,
+                returncode=self._build_process.returncode or -1,
+                stdout="",
+                stderr=b"".join(stderr_chunks).decode("utf-8", errors="replace"),
+            )
 
         if self._build_process.returncode != 0:
-            error_msg = ""
-            if self._build_process.stderr:
-                stderr = await self._build_process.stderr.read()
-                error_msg = stderr.decode("utf-8")
+            error_msg = b"".join(stderr_chunks).decode("utf-8", errors="replace")
             self._add_progress_error(
                 "Build command failed: {msg}", msg=error_msg or "unknown error"
             )
@@ -915,12 +966,11 @@ class BuildOrchestrator:
                 )
             )
 
-        # Return a CompletedProcess-like object for compatibility
         return subprocess.CompletedProcess(
             args=cmd_str,
             returncode=self._build_process.returncode,
-            stdout="",  # stdout was consumed during monitoring
-            stderr="",  # stderr will be read if there's an error
+            stdout="",
+            stderr=b"".join(stderr_chunks).decode("utf-8", errors="replace"),
         )
 
     async def _validate_pci_config(

--- a/src/tui/core/build_orchestrator.py
+++ b/src/tui/core/build_orchestrator.py
@@ -79,6 +79,7 @@ class BuildOrchestrator:
         self._should_cancel = False
         self._executor = ThreadPoolExecutor(max_workers=4)
         self._last_resource_update = 0
+        self._config: Optional[BuildConfiguration] = None
 
     # -----------------------------
     # Internal helpers (errors/logs)
@@ -168,6 +169,7 @@ class BuildOrchestrator:
         self._is_building = True
         self._should_cancel = False
         self._progress_callback = progress_callback
+        self._config = config
 
         # Initialize progress tracking
         self._current_progress = BuildProgress(
@@ -445,10 +447,8 @@ class BuildOrchestrator:
         Raises:
             RuntimeError: If environment validation fails
         """
-        # Get current configuration
-        app = self._get_app()
-        config = getattr(app, "current_config", None)
-        local_build = config and config.local_build
+        config = self._config
+        local_build = bool(config and config.local_build)
 
         if not local_build:
             await self._validate_container_environment()
@@ -461,21 +461,6 @@ class BuildOrchestrator:
 
         # Ensure pcileech-fpga repository is available
         await self._ensure_git_repo()
-
-    def _get_app(self):
-        """
-        Get the parent app instance.
-
-        Returns:
-            The parent app instance or None if not found
-        """
-        # Find the app instance in the widget tree
-        widget = getattr(self, "_progress_callback", None)
-        while widget:
-            if hasattr(widget, "app"):
-                return widget.app
-            widget = getattr(widget, "parent", None)
-        return None
 
     async def _validate_container_environment(self) -> None:
         """

--- a/src/tui/core/config_manager.py
+++ b/src/tui/core/config_manager.py
@@ -239,16 +239,11 @@ class ConfigManager:
                     # If conversion fails, continue with legacy model
                     pass
 
-            # Update last used timestamp
-            timestamp = datetime.now().isoformat()
+            # This is the real load-to-use path — stamp it explicitly.
             if isinstance(config, BuildConfiguration):
-                # For Pydantic model, create a new instance with updated timestamp
-                config_dict = config.dict()
-                config_dict["last_used"] = timestamp
-                config = BuildConfiguration(**config_dict)
+                config.mark_used()
             else:
-                # For legacy model, set attribute directly
-                config.last_used = timestamp
+                config.last_used = datetime.now().isoformat()
             success = self.save_profile(name, config)  # Save updated timestamp
             if not success:
                 # If we couldn't save the updated timestamp, just log and

--- a/src/tui/core/config_manager.py
+++ b/src/tui/core/config_manager.py
@@ -195,15 +195,14 @@ class ConfigManager:
             print(f"Error saving profile: {error.message}")
             return False
 
-    def load_profile(self, name: str) -> Optional[BuildConfiguration]:
-        """
-        Load configuration profile.
+    def _load_profile_raw(self, name: str) -> Optional[BuildConfiguration]:
+        """Read and parse a profile without stamping ``last_used``.
 
-        Returns:
-            Configuration if successful, None otherwise
+        Use this for read-only probes (export, validation, listing). The
+        public ``load_profile`` is the load-to-use path: it stamps and
+        persists; this internal sibling does neither.
         """
         try:
-            # Ensure directory exists
             self._ensure_config_directory()
 
             profile_path = self.config_dir / f"{self._sanitize_filename(name)}.json"
@@ -221,39 +220,18 @@ class ConfigManager:
                 print(f"Profile not found: {error.message}")
                 return None
 
-            # Load the profile data
             with open(profile_path, "r") as f:
                 profile_data = json.load(f)
 
-            # Try to create a Pydantic BuildConfiguration
             try:
-                config = BuildConfiguration(**profile_data)
+                return BuildConfiguration(**profile_data)
             except ValidationError as e:
                 print(f"Warning: Validation errors in profile '{name}': {e}")
-                # Fall back to legacy model if validation fails
                 config = LegacyBuildConfiguration(**profile_data)
-                # Attempt to convert to new model with default values for missing fields
                 try:
-                    config = BuildConfiguration(**config.to_dict())
+                    return BuildConfiguration(**config.to_dict())
                 except ValidationError:
-                    # If conversion fails, continue with legacy model
-                    pass
-
-            # This is the real load-to-use path — stamp it explicitly.
-            if isinstance(config, BuildConfiguration):
-                config.mark_used()
-            else:
-                config.last_used = datetime.now().isoformat()
-            success = self.save_profile(name, config)  # Save updated timestamp
-            if not success:
-                # If we couldn't save the updated timestamp, just log and
-                # continue
-                print(
-                    f"Warning: Could not update last_used timestamp for profile '{name}'"
-                )
-
-            return config
-
+                    return config
         except PermissionError as e:
             error = TUIError(
                 severity=ErrorSeverity.ERROR,
@@ -293,6 +271,35 @@ class ConfigManager:
             )
             print(f"Error loading profile: {error.message}")
             return None
+
+    def load_profile(self, name: str) -> Optional[BuildConfiguration]:
+        """
+        Load configuration profile for *use* — stamps ``last_used`` and
+        persists the change.
+
+        Returns:
+            Configuration if successful, None otherwise.
+        """
+        config = self._load_profile_raw(name)
+        if config is None:
+            return None
+
+        try:
+            if isinstance(config, BuildConfiguration):
+                config.mark_used()
+            else:
+                config.last_used = datetime.now().isoformat()
+            success = self.save_profile(name, config)
+            if not success:
+                print(
+                    f"Warning: Could not update last_used timestamp for profile '{name}'"
+                )
+            return config
+        except Exception as e:
+            # Stamping/persistence failed but the read succeeded — return
+            # the in-memory config so the caller can still use it.
+            print(f"Warning: load_profile stamping failed for '{name}': {e}")
+            return config
 
     def list_profiles(self) -> List[Dict[str, str]]:
         """
@@ -534,28 +541,28 @@ class ConfigManager:
         """
         Export a profile to a specific path.
 
+        Uses the read-only loader so exporting does not re-stamp ``last_used``
+        or rewrite the source profile.
+
         Returns:
             Boolean indicating success
         """
         try:
-            config = self.load_profile(name)
-            if not config:
+            config = self._load_profile_raw(name)
+            if config is None:
                 return False
 
-            if config:
-                try:
-                    config.save_to_file(export_path)
-                    return True
-                except PermissionError as e:
-                    print(
-                        f"Permission denied when exporting profile to {export_path}: {e}"
-                    )
-                    return False
-                except Exception as e:
-                    print(f"Failed to export profile to {export_path}: {e}")
-                    return False
-            print(f"Cannot export profile '{name}' - profile not loaded")
-            return False
+            try:
+                config.save_to_file(export_path)
+                return True
+            except PermissionError as e:
+                print(
+                    f"Permission denied when exporting profile to {export_path}: {e}"
+                )
+                return False
+            except Exception as e:
+                print(f"Failed to export profile to {export_path}: {e}")
+                return False
         except Exception as e:
             print(f"Unexpected error when exporting profile '{name}': {e}")
             return False

--- a/src/tui/core/error_handler.py
+++ b/src/tui/core/error_handler.py
@@ -47,7 +47,7 @@ class ErrorHandler:
 
         # Show user-friendly message
         user_msg = self._get_user_friendly_message(error, context)
-        self.app.notify(user_msg, severity=severity)
+        self.app.log_notification(user_msg, severity=severity)
 
         # Persist full traceback to an error log for later inspection
         try:
@@ -133,7 +133,7 @@ class ErrorHandler:
         # 3. Show a more prominent UI notification
 
         # For now, we'll just show an additional notification with recovery instructions
-        self.app.notify(
+        self.app.log_notification(
             "A critical error occurred. Please save your work and restart the application.",
             severity="error",
         )

--- a/src/tui/core/ui_coordinator.py
+++ b/src/tui/core/ui_coordinator.py
@@ -160,7 +160,9 @@ class UICoordinator:
             self.app.current_config.donor_dump
             and not self.app.current_config.local_build
         ):
-            await self._validate_donor_module()
+            if not await self._validate_donor_module():
+                self.app.notify("Build cancelled", severity="warning")
+                return
 
         try:
             # Update button states

--- a/src/tui/core/ui_coordinator.py
+++ b/src/tui/core/ui_coordinator.py
@@ -52,7 +52,7 @@ class UICoordinator:
         self._update_buttons_for_device_selection(device)
 
         # Notify user
-        self.app.notify(f"Selected device: {device.bdf}", severity="info")
+        self.app.log_notification(f"Selected device: {device.bdf}", severity="info")
 
     async def scan_devices(self) -> List[PCIDevice]:
         """
@@ -76,7 +76,7 @@ class UICoordinator:
             if hasattr(self.app, "error_handler"):
                 self.app.error_handler.handle_operation_error("scanning devices", e)
             else:
-                self.app.notify(f"Failed to scan devices: {e}", severity="error")
+                self.app.log_notification(f"Failed to scan devices: {e}", severity="error")
             return []
 
     def apply_device_filters(self) -> None:
@@ -148,11 +148,11 @@ class UICoordinator:
         Start the build process with validation and error handling
         """
         if not self.app.selected_device:
-            self.app.notify("Please select a device first", severity="error")
+            self.app.log_notification("Please select a device first", severity="error")
             return
 
         if self.build_orchestrator.is_building():
-            self.app.notify("Build already in progress", severity="warning")
+            self.app.log_notification("Build already in progress", severity="warning")
             return
 
         # Check donor module status before starting build if donor_dump is enabled
@@ -161,7 +161,7 @@ class UICoordinator:
             and not self.app.current_config.local_build
         ):
             if not await self._validate_donor_module():
-                self.app.notify("Build cancelled", severity="warning")
+                self.app.log_notification("Build cancelled", severity="warning")
                 return
 
         try:
@@ -177,9 +177,9 @@ class UICoordinator:
             )
 
             if success:
-                self.app.notify("Build completed successfully!", severity="success")
+                self.app.log_notification("Build completed successfully!", severity="success")
             else:
-                self.app.notify("Build was cancelled", severity="warning")
+                self.app.log_notification("Build was cancelled", severity="warning")
 
         except Exception as e:
             error_msg = str(e)
@@ -192,12 +192,12 @@ class UICoordinator:
                     or "platform incompatibility" in error_msg
                     or "only available on Linux" in error_msg
                 ):
-                    self.app.notify(
+                    self.app.log_notification(
                         "Build skipped: Platform compatibility issue (see logs)",
                         severity="warning",
                     )
                 else:
-                    self.app.notify(f"Build failed: {e}", severity="error")
+                    self.app.log_notification(f"Build failed: {e}", severity="error")
         finally:
             # Reset button states
             self.app.query_one("#start-build").disabled = False
@@ -206,7 +206,7 @@ class UICoordinator:
     async def handle_build_stop(self) -> None:
         """Stop the current build process"""
         await self.build_orchestrator.cancel_build()
-        self.app.notify("Build cancelled", severity="info")
+        self.app.log_notification("Build cancelled", severity="info")
 
     def handle_build_progress(self, progress: BuildProgress) -> None:
         """
@@ -266,7 +266,7 @@ class UICoordinator:
 
         if module_status and module_status.get("status") != "installed":
             # Show warning dialog with issues and fixes
-            self.app.notify(
+            self.app.log_notification(
                 "⚠️ Donor module is not properly installed. This may affect the build.",
                 severity="warning",
             )
@@ -276,9 +276,9 @@ class UICoordinator:
             fixes = module_status.get("fixes", [])
 
             if issues:
-                self.app.notify(f"Issues: {issues[0]}", severity="warning")
+                self.app.log_notification(f"Issues: {issues[0]}", severity="warning")
             if fixes:
-                self.app.notify(
+                self.app.log_notification(
                     f"Suggested fix: {fixes[0]}",
                     severity="information",
                 )
@@ -290,7 +290,7 @@ class UICoordinator:
             )
 
             if not should_continue:
-                self.app.notify("Build cancelled by user", severity="information")
+                self.app.log_notification("Build cancelled by user", severity="information")
                 return False
 
         return True
@@ -313,7 +313,7 @@ class UICoordinator:
                 self.config_manager.set_current_config(config)
                 # Update UI displays
                 self._update_config_display()
-                self.app.notify(f"Loaded profile: {profile_name}", severity="success")
+                self.app.log_notification(f"Loaded profile: {profile_name}", severity="success")
                 return config
             return None
         except Exception as e:
@@ -321,7 +321,7 @@ class UICoordinator:
                 self.app.error_handler.handle_operation_error("loading profile", e)
             else:
                 if hasattr(self.app, "notify"):
-                    self.app.notify(f"Failed to load profile: {e}", severity="error")
+                    self.app.log_notification(f"Failed to load profile: {e}", severity="error")
             return None
 
     async def apply_filters(self, filters: Dict[str, Any]) -> None:
@@ -334,13 +334,13 @@ class UICoordinator:
             # Update device panel title
             self._update_device_panel_title()
             if hasattr(self.app, "notify"):
-                self.app.notify("Filters applied", severity="success")
+                self.app.log_notification("Filters applied", severity="success")
         except Exception as e:
             if hasattr(self.app, "error_handler"):
                 self.app.error_handler.handle_operation_error("applying filters", e)
             else:
                 if hasattr(self.app, "notify"):
-                    self.app.notify(f"Failed to apply filters: {e}", severity="error")
+                    self.app.log_notification(f"Failed to apply filters: {e}", severity="error")
 
     def get_current_build_log(self) -> List[str]:
         """Return current build log lines via the build orchestrator."""
@@ -383,7 +383,7 @@ class UICoordinator:
                 DonorInfoTemplateGenerator.save_template(output_path, pretty=True)
 
             if hasattr(self.app, "notify"):
-                self.app.notify(
+                self.app.log_notification(
                     f"✓ Donor info template saved to: {output_path}", severity="success"
                 )
             return output_path
@@ -394,7 +394,7 @@ class UICoordinator:
                 )
             else:
                 if hasattr(self.app, "notify"):
-                    self.app.notify(
+                    self.app.log_notification(
                         f"Failed to generate donor template: {e}", severity="error"
                     )
             return None
@@ -422,15 +422,15 @@ class UICoordinator:
                 status = module_status.get("status")
                 details = module_status.get("details")
                 if status == "installed":
-                    self.app.notify(
+                    self.app.log_notification(
                         f"Donor module status: {details}", severity="success"
                     )
                 elif status in ["built_not_loaded", "loaded_but_error"]:
-                    self.app.notify(
+                    self.app.log_notification(
                         f"Donor module status: {details}", severity="warning"
                     )
                 else:
-                    self.app.notify(f"Donor module status: {details}", severity="error")
+                    self.app.log_notification(f"Donor module status: {details}", severity="error")
 
             return module_status
         except Exception as e:
@@ -444,7 +444,7 @@ class UICoordinator:
                 ],
             }
             if show_notification and hasattr(self.app, "notify"):
-                self.app.notify(
+                self.app.log_notification(
                     f"Failed to check donor module status: {e}", severity="error"
                 )
             if getattr(self.app, "_system_status", None) is not None:
@@ -493,7 +493,7 @@ class UICoordinator:
             # Save the configuration to the config manager
             self.config_manager.set_current_config(config)
             self._update_config_display()
-            self.app.notify("Configuration updated successfully", severity="success")
+            self.app.log_notification("Configuration updated successfully", severity="success")
 
     def _update_config_display(self) -> None:
         """Update configuration display in the UI"""
@@ -531,7 +531,7 @@ class UICoordinator:
                 )
             else:
                 print(f"Error updating configuration display: {e}")
-                self.app.notify("Error displaying configuration", severity="error")
+                self.app.log_notification("Error displaying configuration", severity="error")
 
     def _update_donor_dump_button(self) -> None:
         """Update the donor dump button text and style based on current state"""
@@ -784,7 +784,7 @@ class UICoordinator:
 
             # Notify through app
             if hasattr(self.app, "notify"):
-                self.app.notify(
+                self.app.log_notification(
                     f"Device list exported to {export_path}", severity="success"
                 )
         except Exception as e:
@@ -794,6 +794,6 @@ class UICoordinator:
                 )
             else:
                 if hasattr(self.app, "notify"):
-                    self.app.notify(
+                    self.app.log_notification(
                         f"Failed to export device list: {e}", severity="error"
                     )

--- a/src/tui/core/ui_coordinator.py
+++ b/src/tui/core/ui_coordinator.py
@@ -92,6 +92,8 @@ class UICoordinator:
 
             if search_text:
                 current_filters["search_text"] = search_text
+            else:
+                current_filters.pop("search_text", None)
 
             # Update app state with filters
             self.app.app_state.set_filters(current_filters)

--- a/src/tui/dialogs/base.py
+++ b/src/tui/dialogs/base.py
@@ -1,0 +1,28 @@
+"""Shared modal dialog base class.
+
+Provides escape-to-dismiss and a stable convention for title/button styling
+so individual dialogs don't reinvent scaffolding (and don't collide on IDs
+across the modal screen stack).
+"""
+
+from typing import Generic, TypeVar
+
+from textual.binding import Binding
+from textual.screen import ModalScreen
+
+T = TypeVar("T")
+
+
+class BaseDialog(ModalScreen[T], Generic[T]):
+    """ModalScreen with a uniform Escape binding.
+
+    Subclasses returning a non-None default on dismiss should override
+    ``action_dismiss_dialog``.
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss_dialog", "Close", priority=True),
+    ]
+
+    def action_dismiss_dialog(self) -> None:
+        self.dismiss(None)

--- a/src/tui/dialogs/build_log.py
+++ b/src/tui/dialogs/build_log.py
@@ -124,7 +124,7 @@ class BuildLogDialog(BaseDialog[bool]):
             severity: The severity level (error, warning, information, success).
         """
         try:
-            self.app.notify(message, severity=severity)
+            self.app.log_notification(message, severity=severity)
         except Exception:
             # If notification fails, we can't do much - silent failure
             pass

--- a/src/tui/dialogs/build_log.py
+++ b/src/tui/dialogs/build_log.py
@@ -16,11 +16,12 @@ except ImportError:
 # Third-party imports
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, VerticalScroll
-from textual.screen import ModalScreen
 from textual.widgets import Button, DataTable, RichLog, Static
 
+from .base import BaseDialog
 
-class BuildLogDialog(ModalScreen[bool]):
+
+class BuildLogDialog(BaseDialog[bool]):
     """Modal dialog showing current build log, history and system info.
 
     This implementation uses simple Container elements instead of TabbedContent/TabPane
@@ -63,7 +64,7 @@ class BuildLogDialog(ModalScreen[bool]):
             ComposeResult: The composed UI elements.
         """
         with Container(id="build-log-dialog"):
-            yield Static("Build Logs & History", id="dialog-title")
+            yield Static("Build Logs & History", classes="dialog-title")
 
             # Current build log section
             with Container(id="current-build"):
@@ -106,8 +107,8 @@ class BuildLogDialog(ModalScreen[bool]):
                 with VerticalScroll():
                     yield Static(id="system-info-content")
 
-            with Horizontal(id="dialog-buttons"):
-                yield Button("Close", id="close-logs", variant="default")
+            with Horizontal(classes="dialog-buttons"):
+                yield Button("Close", id="close-logs", variant="primary")
 
     def on_mount(self) -> None:
         """Initialize the dialog content when it's mounted."""

--- a/src/tui/dialogs/configuration.py
+++ b/src/tui/dialogs/configuration.py
@@ -2,11 +2,12 @@ from typing import Any, Dict
 
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
-from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Static
 
+from .base import BaseDialog
 
-class ConfigurationDialog(ModalScreen[dict | None]):
+
+class ConfigurationDialog(BaseDialog[dict | None]):
     """Modal dialog to edit a simple configuration dict."""
 
     def __init__(self, title: str, config: Dict[str, Any]):
@@ -16,15 +17,14 @@ class ConfigurationDialog(ModalScreen[dict | None]):
 
     def compose(self) -> ComposeResult:
         with Container(id="config-dialog"):
-            yield Static(self.title, id="config-title")
+            yield Static(self.title, classes="dialog-title")
 
             with Vertical(id="config-items"):
-                # Render simple key/value pairs as Input widgets
                 for key, value in self.config.items():
                     yield Static(key)
                     yield Input(value=str(value), id=f"config-{key}")
 
-            with Horizontal(id="dialog-buttons"):
+            with Horizontal(classes="dialog-buttons"):
                 yield Button("Cancel", id="cancel-config", variant="default")
                 yield Button("Save", id="save-config", variant="primary")
 
@@ -33,7 +33,6 @@ class ConfigurationDialog(ModalScreen[dict | None]):
         if button_id == "cancel-config":
             self.dismiss(None)
         elif button_id == "save-config":
-            # gather inputs back into dict
             new_conf: Dict[str, Any] = {}
             for key in self.config.keys():
                 input_widget = self.query_one(f"#config-{key}", Input)

--- a/src/tui/dialogs/configuration.py
+++ b/src/tui/dialogs/configuration.py
@@ -1,14 +1,29 @@
+import json
 from typing import Any, Dict
 
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
-from textual.widgets import Button, Input, Static
+from textual.widgets import Button, Checkbox, Input, Static
 
 from .base import BaseDialog
 
+# Field names whose values are dict/list (rendered as JSON in an Input).
+# Kept as a constant so a regression in BuildConfiguration's schema is loud.
+JSON_FIELDS = ("custom_parameters", "feature_flags", "compatibility_overrides")
+
+
+def _widget_id(key: str) -> str:
+    return f"config-{key}"
+
 
 class ConfigurationDialog(BaseDialog[dict | None]):
-    """Modal dialog to edit a simple configuration dict."""
+    """Modal dialog to edit a BuildConfiguration dict.
+
+    Bool fields render as a Checkbox; dict/list fields render as JSON in an
+    Input and parse with json.loads on save; int/float fields parse with
+    their constructor and surface errors via app.notify instead of silently
+    corrupting the value.
+    """
 
     def __init__(self, title: str, config: Dict[str, Any]):
         super().__init__()
@@ -22,19 +37,73 @@ class ConfigurationDialog(BaseDialog[dict | None]):
             with Vertical(id="config-items"):
                 for key, value in self.config.items():
                     yield Static(key)
-                    yield Input(value=str(value), id=f"config-{key}")
+                    if isinstance(value, bool):
+                        yield Checkbox(value=value, id=_widget_id(key))
+                    elif key in JSON_FIELDS or isinstance(value, (dict, list)):
+                        yield Input(
+                            value=json.dumps(value),
+                            id=_widget_id(key),
+                        )
+                    else:
+                        yield Input(value="" if value is None else str(value), id=_widget_id(key))
 
             with Horizontal(classes="dialog-buttons"):
                 yield Button("Cancel", id="cancel-config", variant="default")
                 yield Button("Save", id="save-config", variant="primary")
 
+    def _notify_error(self, message: str) -> None:
+        try:
+            self.app.log_notification(message, severity="error")
+        except Exception:
+            pass
+
+    def _coerce(self, key: str, original: Any, raw: Any) -> Any:
+        """Coerce a raw widget value back to the original field type.
+
+        Raises ValueError on parse failure; the caller surfaces it.
+        """
+        if isinstance(original, bool):
+            return bool(raw)
+        if key in JSON_FIELDS or isinstance(original, (dict, list)):
+            try:
+                return json.loads(raw) if isinstance(raw, str) else raw
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{key}: invalid JSON ({exc.msg})") from exc
+        if isinstance(original, int) and not isinstance(original, bool):
+            try:
+                return int(raw)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"{key}: expected an integer") from exc
+        if isinstance(original, float):
+            try:
+                return float(raw)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"{key}: expected a number") from exc
+        if original is None and raw == "":
+            return None
+        return raw
+
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         button_id = event.button.id
         if button_id == "cancel-config":
             self.dismiss(None)
-        elif button_id == "save-config":
-            new_conf: Dict[str, Any] = {}
-            for key in self.config.keys():
-                input_widget = self.query_one(f"#config-{key}", Input)
-                new_conf[key] = input_widget.value
-            self.dismiss(new_conf)
+            return
+        if button_id != "save-config":
+            return
+
+        new_conf: Dict[str, Any] = {}
+        for key, original in self.config.items():
+            try:
+                widget = self.query_one(f"#{_widget_id(key)}")
+            except Exception:
+                # Widget missing (shouldn't happen) — keep original value
+                new_conf[key] = original
+                continue
+            raw = widget.value
+            try:
+                new_conf[key] = self._coerce(key, original, raw)
+            except ValueError as exc:
+                self._notify_error(str(exc))
+                return  # leave dialog open so user can fix it
+
+        self.dismiss(new_conf)

--- a/src/tui/dialogs/configuration.py
+++ b/src/tui/dialogs/configuration.py
@@ -21,8 +21,8 @@ class ConfigurationDialog(BaseDialog[dict | None]):
 
     Bool fields render as a Checkbox; dict/list fields render as JSON in an
     Input and parse with json.loads on save; int/float fields parse with
-    their constructor and surface errors via app.notify instead of silently
-    corrupting the value.
+    their constructor and surface errors via ``app.log_notification`` (T7
+    rename) instead of silently corrupting the value.
     """
 
     def __init__(self, title: str, config: Dict[str, Any]):
@@ -55,6 +55,7 @@ class ConfigurationDialog(BaseDialog[dict | None]):
         try:
             self.app.log_notification(message, severity="error")
         except Exception:
+            # Best-effort UI notification — never raise from this path.
             pass
 
     def _coerce(self, key: str, original: Any, raw: Any) -> Any:

--- a/src/tui/dialogs/confirmation.py
+++ b/src/tui/dialogs/confirmation.py
@@ -1,11 +1,11 @@
-
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
-from textual.screen import ModalScreen
 from textual.widgets import Button, Static
 
+from .base import BaseDialog
 
-class ConfirmationDialog(ModalScreen[bool]):
+
+class ConfirmationDialog(BaseDialog[bool]):
     """Modal dialog for confirming actions with warnings"""
 
     def __init__(self, title: str, message: str) -> None:
@@ -15,14 +15,17 @@ class ConfirmationDialog(ModalScreen[bool]):
 
     def compose(self) -> ComposeResult:
         with Container(id="confirm-dialog"):
-            yield Static(self.title, id="dialog-title")
+            yield Static(self.title, classes="dialog-title")
 
             with Vertical(id="confirm-message"):
                 yield Static(self.message)
 
-            with Horizontal(id="dialog-buttons"):
+            with Horizontal(classes="dialog-buttons"):
                 yield Button("Cancel", id="cancel-confirm", variant="default")
                 yield Button("Continue", id="confirm-action", variant="primary")
+
+    def action_dismiss_dialog(self) -> None:
+        self.dismiss(False)
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         button_id = event.button.id

--- a/src/tui/dialogs/device_details.py
+++ b/src/tui/dialogs/device_details.py
@@ -167,7 +167,7 @@ class DeviceDetailsDialog(BaseDialog[bool]):
             severity: The severity level (success, error, information)
         """
         try:
-            self.app.notify(message, severity=severity)
+            self.app.log_notification(message, severity=severity)
         except Exception:
             # notify may not exist on minimal test harnesses
             pass

--- a/src/tui/dialogs/device_details.py
+++ b/src/tui/dialogs/device_details.py
@@ -4,11 +4,12 @@ from typing import Any
 
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, VerticalScroll
-from textual.screen import ModalScreen
 from textual.widgets import Button, Static
 
+from .base import BaseDialog
 
-class DeviceDetailsDialog(ModalScreen[bool]):
+
+class DeviceDetailsDialog(BaseDialog[bool]):
     """Modal dialog for displaying detailed device information.
 
     This implementation uses plain Containers/VerticalScroll instead of
@@ -29,7 +30,7 @@ class DeviceDetailsDialog(ModalScreen[bool]):
         with Container(id="device-details-dialog"):
             yield Static(
                 f"📡 Device Details: {self._get_device_attr('bdf', 'unknown')}",
-                id="dialog-title",
+                classes="dialog-title",
             )
 
             # Basic Info section
@@ -99,9 +100,9 @@ class DeviceDetailsDialog(ModalScreen[bool]):
                     ).items():
                         yield Static(f"{key}: {value}")
 
-            with Horizontal(id="dialog-buttons"):
-                yield Button("Export Details", id="export-details", variant="primary")
+            with Horizontal(classes="dialog-buttons"):
                 yield Button("Close", id="close-details", variant="default")
+                yield Button("Export Details", id="export-details", variant="primary")
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "close-details":

--- a/src/tui/dialogs/file_path_input.py
+++ b/src/tui/dialogs/file_path_input.py
@@ -1,10 +1,11 @@
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
-from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Static
 
+from .base import BaseDialog
 
-class FilePathInputDialog(ModalScreen[str | None]):
+
+class FilePathInputDialog(BaseDialog[str | None]):
     """Modal input dialog to get a file path from the user."""
 
     def __init__(self, prompt: str, default: str | None = None) -> None:
@@ -14,7 +15,7 @@ class FilePathInputDialog(ModalScreen[str | None]):
 
     def compose(self) -> ComposeResult:
         with Container(id="file-path-dialog"):
-            yield Static(self.prompt, id="dialog-prompt")
+            yield Static(self.prompt, classes="dialog-title")
 
             with Vertical(id="file-path-input"):
                 yield Input(
@@ -23,7 +24,7 @@ class FilePathInputDialog(ModalScreen[str | None]):
                     id="path-input",
                 )
 
-            with Horizontal(id="dialog-buttons"):
+            with Horizontal(classes="dialog-buttons"):
                 yield Button("Cancel", id="cancel-path", variant="default")
                 yield Button("Ok", id="confirm-path", variant="primary")
 

--- a/src/tui/dialogs/help_dialog.py
+++ b/src/tui/dialogs/help_dialog.py
@@ -2,8 +2,9 @@ from typing import Optional
 
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, VerticalScroll
-from textual.screen import ModalScreen
 from textual.widgets import Button, Static
+
+from .base import BaseDialog
 
 DEFAULT_HELP_TEXT = """
 PCILeech Firmware Generator - Keyboard Shortcuts
@@ -38,7 +39,7 @@ Tips:
 """
 
 
-class HelpDialog(ModalScreen[bool]):
+class HelpDialog(BaseDialog[bool]):
     """Modal dialog that displays help text."""
 
     def __init__(self, help_text: Optional[str] = None) -> None:
@@ -47,13 +48,16 @@ class HelpDialog(ModalScreen[bool]):
 
     def compose(self) -> ComposeResult:
         with Container(id="help-dialog"):
-            yield Static("📚 PCILeech Help", id="dialog-title")
+            yield Static("📚 PCILeech Help", classes="dialog-title")
 
             with VerticalScroll():
                 yield Static(self.help_text, id="help-content")
 
-            with Horizontal(id="dialog-buttons"):
+            with Horizontal(classes="dialog-buttons"):
                 yield Button("Close", variant="primary", id="close-help")
+
+    def action_dismiss_dialog(self) -> None:
+        self.dismiss(True)
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "close-help":

--- a/src/tui/dialogs/profile_manager.py
+++ b/src/tui/dialogs/profile_manager.py
@@ -105,12 +105,14 @@ class ProfileManagerDialog(BaseDialog[Optional[str]]):
         try:
             self.app.log_notification(message, severity="error")
         except Exception:
+            # Best-effort UI notification — never raise from this path.
             pass
 
     def _notify_info(self, message: str) -> None:
         try:
             self.app.log_notification(message, severity="information")
         except Exception:
+            # Best-effort UI notification — never raise from this path.
             pass
 
     # ---- button actions -------------------------------------------------

--- a/src/tui/dialogs/profile_manager.py
+++ b/src/tui/dialogs/profile_manager.py
@@ -2,11 +2,12 @@ from typing import Dict, List, Optional
 
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
-from textual.screen import ModalScreen
 from textual.widgets import Button, DataTable, Static
 
+from .base import BaseDialog
 
-class ProfileManagerDialog(ModalScreen[Optional[str]]):
+
+class ProfileManagerDialog(BaseDialog[Optional[str]]):
     """Modal dialog for managing configuration profiles"""
 
     def __init__(self, config_manager) -> None:
@@ -16,7 +17,7 @@ class ProfileManagerDialog(ModalScreen[Optional[str]]):
 
     def compose(self) -> ComposeResult:
         with Container(id="profile-manager-dialog"):
-            yield Static("📋 Configuration Profiles", id="dialog-title")
+            yield Static("📋 Configuration Profiles", classes="dialog-title")
 
             with Horizontal():
                 with Vertical(id="profile-list-panel"):
@@ -42,8 +43,8 @@ class ProfileManagerDialog(ModalScreen[Optional[str]]):
                             "Create New", id="create-profile-btn", variant="primary"
                         )
 
-            with Horizontal(id="dialog-buttons"):
-                yield Button("Close", id="close-profiles", variant="default")
+            with Horizontal(classes="dialog-buttons"):
+                yield Button("Close", id="close-profiles", variant="primary")
 
     def on_mount(self) -> None:
         self._refresh_profiles()

--- a/src/tui/dialogs/profile_manager.py
+++ b/src/tui/dialogs/profile_manager.py
@@ -69,7 +69,7 @@ class ProfileManagerDialog(BaseDialog[Optional[str]]):
                 )
         except Exception:
             try:
-                self.app.notify("Failed to load profiles", severity="error")
+                self.app.log_notification("Failed to load profiles", severity="error")
             except Exception:
                 pass
 
@@ -103,13 +103,13 @@ class ProfileManagerDialog(BaseDialog[Optional[str]]):
 
     def _notify_error(self, message: str) -> None:
         try:
-            self.app.notify(message, severity="error")
+            self.app.log_notification(message, severity="error")
         except Exception:
             pass
 
     def _notify_info(self, message: str) -> None:
         try:
-            self.app.notify(message, severity="information")
+            self.app.log_notification(message, severity="information")
         except Exception:
             pass
 

--- a/src/tui/dialogs/profile_manager.py
+++ b/src/tui/dialogs/profile_manager.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Dict, List, Optional
 
 from textual.app import ComposeResult
@@ -5,6 +6,8 @@ from textual.containers import Container, Horizontal, Vertical
 from textual.widgets import Button, DataTable, Static
 
 from .base import BaseDialog
+from .confirmation import ConfirmationDialog
+from .file_path_input import FilePathInputDialog
 
 
 class ProfileManagerDialog(BaseDialog[Optional[str]]):
@@ -85,4 +88,126 @@ class ProfileManagerDialog(BaseDialog[Optional[str]]):
         elif button_id == "create-profile-btn":
             await self._create_new_profile()
 
-    # The rest of the helper methods are intentionally left in the main app where they are coupled to app services
+    # ---- helpers --------------------------------------------------------
+
+    def _selected_profile_name(self) -> Optional[str]:
+        """Return the profile name corresponding to the highlighted row."""
+        try:
+            table = self.query_one("#profiles-table", DataTable)
+            row = table.cursor_row
+        except Exception:
+            return None
+        if row is None or row < 0 or row >= len(self.profiles):
+            return None
+        return self.profiles[row].get("name")
+
+    def _notify_error(self, message: str) -> None:
+        try:
+            self.app.notify(message, severity="error")
+        except Exception:
+            pass
+
+    def _notify_info(self, message: str) -> None:
+        try:
+            self.app.notify(message, severity="information")
+        except Exception:
+            pass
+
+    # ---- button actions -------------------------------------------------
+
+    async def _load_selected_profile(self) -> None:
+        name = self._selected_profile_name()
+        if not name:
+            self._notify_error("Select a profile to load")
+            return
+        # Caller in main.py reads the dismiss value and applies the profile.
+        self.dismiss(name)
+
+    async def _delete_selected_profile(self) -> None:
+        name = self._selected_profile_name()
+        if not name:
+            self._notify_error("Select a profile to delete")
+            return
+
+        confirmed = await self.app.push_screen_wait(
+            ConfirmationDialog(
+                "Delete Profile",
+                f"Delete profile '{name}'? This cannot be undone.",
+            )
+        )
+        if not confirmed:
+            return
+
+        try:
+            ok = self.config_manager.delete_profile(name)
+            if not ok:
+                self._notify_error(f"Failed to delete profile '{name}'")
+                return
+            self._notify_info(f"Deleted profile '{name}'")
+            self._refresh_profiles()
+        except Exception as exc:
+            self._notify_error(f"Delete failed: {exc}")
+
+    async def _export_selected_profile(self) -> None:
+        name = self._selected_profile_name()
+        if not name:
+            self._notify_error("Select a profile to export")
+            return
+
+        path_str = await self.app.push_screen_wait(
+            FilePathInputDialog(
+                f"Export '{name}' to file path:",
+                default=f"{name}.json",
+            )
+        )
+        if not path_str:
+            return
+
+        try:
+            ok = self.config_manager.export_profile(name, Path(path_str))
+            if ok:
+                self._notify_info(f"Exported profile '{name}' to {path_str}")
+            else:
+                self._notify_error(f"Failed to export profile '{name}'")
+        except Exception as exc:
+            self._notify_error(f"Export failed: {exc}")
+
+    async def _import_profile(self) -> None:
+        path_str = await self.app.push_screen_wait(
+            FilePathInputDialog("Import profile from file path:")
+        )
+        if not path_str:
+            return
+
+        try:
+            new_name = self.config_manager.import_profile(Path(path_str))
+            if not new_name:
+                self._notify_error(f"Failed to import profile from {path_str}")
+                return
+            self._notify_info(f"Imported profile '{new_name}'")
+            self._refresh_profiles()
+        except Exception as exc:
+            self._notify_error(f"Import failed: {exc}")
+
+    async def _create_new_profile(self) -> None:
+        # TODO(tui-pass-2): replace FilePathInputDialog with a dedicated
+        # name-input primitive. Reusing it here keeps scope contained.
+        name = await self.app.push_screen_wait(
+            FilePathInputDialog("New profile name:")
+        )
+        if not name:
+            return
+
+        try:
+            current = getattr(self.app, "current_config", None)
+            if current is None:
+                self._notify_error("No current configuration to save")
+                return
+            ok = self.config_manager.save_profile(name, current)
+            if not ok:
+                self._notify_error(f"Failed to save profile '{name}'")
+                return
+            self._notify_info(f"Created profile '{name}'")
+            self._refresh_profiles()
+        except Exception as exc:
+            self._notify_error(f"Create failed: {exc}")

--- a/src/tui/dialogs/search_filter.py
+++ b/src/tui/dialogs/search_filter.py
@@ -2,16 +2,17 @@ from typing import Any, Dict
 
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
-from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label, Select, Static
 
+from .base import BaseDialog
 
-class SearchFilterDialog(ModalScreen[Dict[str, Any]]):
+
+class SearchFilterDialog(BaseDialog[Dict[str, Any]]):
     """Modal dialog for searching and filtering devices"""
 
     def compose(self) -> ComposeResult:
         with Container(id="search-filter-dialog"):
-            yield Static("🔍 Search & Filter Devices", id="dialog-title")
+            yield Static("🔍 Search & Filter Devices", classes="dialog-title")
 
             with Vertical(id="search-form"):
                 yield Label("Search by Device Name:")
@@ -50,16 +51,13 @@ class SearchFilterDialog(ModalScreen[Dict[str, Any]]):
                 yield Label("Minimum Suitability Score:")
                 yield Input(placeholder="0.0 - 1.0", value="0.0", id="score-filter")
 
-            with Horizontal(id="dialog-buttons"):
+            with Horizontal(classes="dialog-buttons"):
                 yield Button("Clear", id="clear-filters", variant="default")
                 yield Button("Apply", id="apply-filters", variant="primary")
-                yield Button("Cancel", id="cancel-search", variant="default")
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         button_id = event.button.id
-        if button_id == "cancel-search":
-            self.dismiss(None)
-        elif button_id == "clear-filters":
+        if button_id == "clear-filters":
             self._clear_all_filters()
         elif button_id == "apply-filters":
             filters = self._get_filter_criteria()

--- a/src/tui/main.py
+++ b/src/tui/main.py
@@ -850,11 +850,13 @@ class PCILeechTUI(App):
     async def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
         """Handle device table row selection"""
         row_key = event.row_key
+        # RowKey is a wrapper around the str key supplied to add_row(); compare
+        # against its .value so we don't depend on Textual's RowKey __eq__.
+        key_value = str(getattr(row_key, "value", row_key))
 
-        # Find selected device
         selected_device = None
-        for device in self.filtered_devices:  # Use computed property
-            if device.bdf == row_key:
+        for device in self.filtered_devices:
+            if device.bdf == key_value:
                 selected_device = device
                 break
 

--- a/src/tui/main.py
+++ b/src/tui/main.py
@@ -920,21 +920,17 @@ class PCILeechTUI(App):
             return False
 
     async def _generate_donor_template(self) -> None:
-        """Generate a donor info template file"""
-        try:
-            # Delegate generation to the coordinator which centralizes logic
-            output_path = await self.ui_coordinator.generate_donor_template()
-            if output_path:
-                self.log_notification(
-                    f"✓ Donor info template saved to: {output_path}", severity="success"
-                )
-                self.log_notification(
-                    "Fill in the device-specific values and use it for advanced cloning",
-                    severity="information",
-                )
+        """Generate a donor info template file.
 
-        except Exception as e:
-            self.log_notification(f"Failed to generate donor template: {e}", severity="error")
+        The coordinator owns the success/failure notification; here we only
+        layer on the secondary hint about how to use the file.
+        """
+        output_path = await self.ui_coordinator.generate_donor_template()
+        if output_path:
+            self.log_notification(
+                "Fill in the device-specific values and use it for advanced cloning",
+                severity="information",
+            )
 
     # App state handler
     def _on_state_change(

--- a/src/tui/main.py
+++ b/src/tui/main.py
@@ -93,6 +93,7 @@ class PCILeechTUI(App):
 
         # Initialize app state
         self.app_state = AppState()
+        self.app_state.subscribe(self._on_state_change)
 
         # Core services
         self.device_manager = DeviceManager()
@@ -133,9 +134,6 @@ class PCILeechTUI(App):
         except Exception:
             # Don't fail initialization if handlers can't be installed
             pass
-
-        # Set up state change handler
-        self.app_state.subscribe(self._on_state_change)
 
     # Keyboard action handlers
     def action_quit(self) -> None:

--- a/src/tui/main.py
+++ b/src/tui/main.py
@@ -383,12 +383,12 @@ class PCILeechTUI(App):
         # Load default configuration profiles with error handling
         success = self.config_manager.create_default_profiles()
         if not success:
-            self.notify(
+            self.log_notification(
                 "Warning: Failed to create default profiles", severity="warning"
             )
 
             # No longer have error object with suggested actions
-            self.notify(
+            self.log_notification(
                 "Check configuration directory permissions", severity="information"
             )
 
@@ -402,7 +402,7 @@ class PCILeechTUI(App):
         self._update_config_display()
 
         # Show welcome message with keyboard shortcuts
-        self.notify(
+        self.log_notification(
             "Welcome! Press F1 or Ctrl+H for help, Ctrl+Q to quit", severity="info"
         )
 
@@ -430,7 +430,7 @@ class PCILeechTUI(App):
                 await self.ui_coordinator.scan_devices()
             except Exception as e:
                 # Fallback to notify on failure
-                self.notify(f"Failed to scan devices: {e}", severity="error")
+                self.log_notification(f"Failed to scan devices: {e}", severity="error")
 
         elif button_id == "start-build":
             await self.ui_coordinator.handle_build_start()
@@ -491,7 +491,7 @@ class PCILeechTUI(App):
                 # Delegate profile loading and state update to coordinator
                 await self.ui_coordinator.load_profile_by_name(result)
         except Exception as e:
-            self.notify(f"Failed to open profile manager: {e}", severity="error")
+            self.log_notification(f"Failed to open profile manager: {e}", severity="error")
 
     async def _open_search_filter(self) -> None:
         """Open the search/filter dialog"""
@@ -501,14 +501,14 @@ class PCILeechTUI(App):
                 # Delegate applying filters to coordinator
                 await self.ui_coordinator.apply_filters(result)
         except Exception as e:
-            self.notify(f"Failed to open search dialog: {e}", severity="error")
+            self.log_notification(f"Failed to open search dialog: {e}", severity="error")
 
     async def _show_device_details(self, device: PCIDevice) -> None:
         """Show detailed device information"""
         try:
             await self.push_screen(DeviceDetailsDialog(device))
         except Exception as e:
-            self.notify(f"Failed to show device details: {e}", severity="error")
+            self.log_notification(f"Failed to show device details: {e}", severity="error")
 
     async def _open_build_logs(self) -> None:
         """Open the build logs dialog"""
@@ -516,7 +516,7 @@ class PCILeechTUI(App):
             # Use coordinator helpers to get logs when populating the dialog
             await self.push_screen(BuildLogDialog(self.build_orchestrator))
         except Exception as e:
-            self.notify(f"Failed to open build logs: {e}", severity="error")
+            self.log_notification(f"Failed to open build logs: {e}", severity="error")
 
     async def _show_help(self) -> None:
         """Show help information"""
@@ -538,9 +538,9 @@ class PCILeechTUI(App):
             with open(backup_path, "w") as f:
                 json.dump(config_data, f, indent=2)
 
-            self.notify(f"Configuration backed up to {backup_path}", severity="success")
+            self.log_notification(f"Configuration backed up to {backup_path}", severity="success")
         except Exception as e:
-            self.notify(f"Failed to backup configuration: {e}", severity="error")
+            self.log_notification(f"Failed to backup configuration: {e}", severity="error")
 
     async def _open_output_directory(self) -> None:
         """Open the output directory"""
@@ -563,18 +563,18 @@ class PCILeechTUI(App):
                                     ["explorer", str(output_dir)], check=False
                                 )  # Windows
                             except (FileNotFoundError, subprocess.CalledProcessError):
-                                self.notify(
+                                self.log_notification(
                                     f"Please manually open: {output_dir.absolute()}",
                                     severity="info",
                                 )
                 else:
-                    self.notify(
+                    self.log_notification(
                         f"Output directory: {output_dir.absolute()}", severity="info"
                     )
             else:
-                self.notify("Output directory does not exist yet", severity="warning")
+                self.log_notification("Output directory does not exist yet", severity="warning")
         except Exception as e:
-            self.notify(f"Failed to open output directory: {e}", severity="error")
+            self.log_notification(f"Failed to open output directory: {e}", severity="error")
 
     async def _view_last_build_report(self) -> None:
         """View the last build report"""
@@ -589,13 +589,13 @@ class PCILeechTUI(App):
                 status = report_data.get("status", "Unknown")
                 device = report_data.get("device", "Unknown")
 
-                self.notify(
+                self.log_notification(
                     f"Last build: {device} - {status} at {build_time}", severity="info"
                 )
             else:
-                self.notify("No build report found", severity="warning")
+                self.log_notification("No build report found", severity="warning")
         except Exception as e:
-            self.notify(f"Failed to read build report: {e}", severity="error")
+            self.log_notification(f"Failed to read build report: {e}", severity="error")
 
     async def _open_documentation(self) -> None:
         """Open documentation"""
@@ -604,17 +604,17 @@ class PCILeechTUI(App):
             docs_path = Path("docs/_build/html/index.html")
             if docs_path.exists():
                 webbrowser.open(f"file://{docs_path.absolute()}")
-                self.notify("Opening local documentation", severity="info")
+                self.log_notification("Opening local documentation", severity="info")
             else:
                 # Fallback to online documentation
                 webbrowser.open("https://pcileechfwgenerator.voltcyclone.info")
-                self.notify("Opening online documentation", severity="info")
+                self.log_notification("Opening online documentation", severity="info")
         except Exception as e:
-            self.notify(f"Failed to open documentation: {e}", severity="error")
+            self.log_notification(f"Failed to open documentation: {e}", severity="error")
 
     async def _open_advanced_settings(self) -> None:
         """Open advanced settings"""
-        self.notify(
+        self.log_notification(
             "Advanced settings - use Configure button for full options", severity="info"
         )
 
@@ -624,13 +624,16 @@ class PCILeechTUI(App):
 
         return datetime.now().isoformat()
 
-    def notify(self, message: str, severity: str = "info") -> None:
+    def log_notification(self, message: str, severity: str = "info") -> None:
         """
-        Display a persistent notification in the notification log and log it.
+        Append a timestamped entry to the persistent `#notification-log`.
 
-        This replaces ephemeral notifications that could be overwritten when
-        the terminal redraws or when the mouse moves. Important messages
-        (warnings/errors) will remain in the `#notification-log` area.
+        Use this for messages that must remain visible after the moment they
+        fire. For ephemeral toasts (Textual's `Notification`), call
+        `self.log_notification(...)` directly — that's now Textual's built-in.
+
+        Accepts `"info"`, `"success"`, `"warning"`, `"error"`, or
+        `"information"` for severity; only used as a tag in the log line.
         """
         try:
             from datetime import datetime
@@ -639,18 +642,16 @@ class PCILeechTUI(App):
             sev = severity.upper()
             line = f"[{ts}] [{sev}] {message}"
 
-            # Append to RichLog if present
             try:
                 log_widget = self.query_one("#notification-log", RichLog)
                 log_widget.write(line)
             except Exception:
-                # If UI not yet ready, or widget missing, fall back to logger
                 import logging
 
                 logging.getLogger(__name__).info(line)
 
         except Exception:
-            # Never raise from notify - best effort only
+            # Best effort — never raise from a notification path.
             pass
 
     def _install_global_exception_handlers(self) -> None:
@@ -692,7 +693,7 @@ class PCILeechTUI(App):
                     # Only show a short one-line notification to avoid UI corruption
                     short = f"Unhandled {exc_type.__name__}: {str(exc_value)}"
                     if hasattr(self, "notify"):
-                        self.notify(short, severity="error")
+                        self.log_notification(short, severity="error")
                 except Exception:
                     # Ignore notification errors
                     pass
@@ -900,7 +901,7 @@ class PCILeechTUI(App):
             else:
                 error_msg = f"Failed to open configuration dialog: {e}"
                 print(f"ERROR: {error_msg}")
-                self.notify(error_msg, severity="error")
+                self.log_notification(error_msg, severity="error")
 
     async def _confirm_with_warnings(self, title: str, message: str) -> bool:
         """Open a confirmation dialog with warnings and return user's choice"""
@@ -913,7 +914,7 @@ class PCILeechTUI(App):
                     "opening confirmation dialog", e
                 )
             else:
-                self.notify(
+                self.log_notification(
                     f"Failed to open confirmation dialog: {e}", severity="error"
                 )
             return False
@@ -924,16 +925,16 @@ class PCILeechTUI(App):
             # Delegate generation to the coordinator which centralizes logic
             output_path = await self.ui_coordinator.generate_donor_template()
             if output_path:
-                self.notify(
+                self.log_notification(
                     f"✓ Donor info template saved to: {output_path}", severity="success"
                 )
-                self.notify(
+                self.log_notification(
                     "Fill in the device-specific values and use it for advanced cloning",
                     severity="information",
                 )
 
         except Exception as e:
-            self.notify(f"Failed to generate donor template: {e}", severity="error")
+            self.log_notification(f"Failed to generate donor template: {e}", severity="error")
 
     # App state handler
     def _on_state_change(
@@ -1072,7 +1073,7 @@ class PCILeechTUI(App):
 
         except Exception as e:
             if show_notification:
-                self.notify(
+                self.log_notification(
                     f"Failed to check donor module status: {e}", severity="error"
                 )
 
@@ -1109,7 +1110,7 @@ class PCILeechTUI(App):
             self.config_manager.set_current_config(current_config)
             self._update_config_display()
             self._update_donor_dump_button()
-            self.notify("Donor dump disabled - using local build mode", severity="info")
+            self.log_notification("Donor dump disabled - using local build mode", severity="info")
         else:
             # Enable donor dump
             current_config.donor_dump = True
@@ -1118,7 +1119,7 @@ class PCILeechTUI(App):
             self.config_manager.set_current_config(current_config)
             self._update_config_display()
             self._update_donor_dump_button()
-            self.notify(
+            self.log_notification(
                 "Donor dump enabled - device analysis will be performed",
                 severity="success",
             )

--- a/src/tui/main.py
+++ b/src/tui/main.py
@@ -886,13 +886,18 @@ class PCILeechTUI(App):
             result = await self.push_screen(
                 ConfigurationDialog("Build Configuration", self.current_config.to_dict())
             )
-            if result is not None:
-                # Convert dict back to BuildConfiguration
+            if result is None:
+                return
+            try:
                 config = BuildConfiguration.from_dict(result)
-                # Update app state first
-                self.app_state.set_config(config)
-                # Then delegate configuration update to UI coordinator
-                await self.ui_coordinator.handle_configuration_update(config)
+            except Exception as exc:
+                # Surface validation failures; leave the live config intact.
+                self.log_notification(
+                    f"Invalid configuration: {exc}", severity="error"
+                )
+                return
+            self.app_state.set_config(config)
+            await self.ui_coordinator.handle_configuration_update(config)
         except Exception as e:
             if hasattr(self, "error_handler"):
                 self.error_handler.handle_operation_error(

--- a/src/tui/models/configuration.py
+++ b/src/tui/models/configuration.py
@@ -205,15 +205,29 @@ class BuildConfiguration(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def set_timestamps(cls, values):
-        """Set timestamps if not provided."""
+        """Set timestamps only when missing.
+
+        Previously this unconditionally rewrote ``last_used`` on every
+        construction, so every read-path that round-tripped through
+        BuildConfiguration(...) clobbered the value. Now the validator
+        treats existing values as authoritative. Use ``mark_used()`` to
+        record an intentional usage.
+        """
         if isinstance(values, dict):
             if values.get("created_at") is None:
                 values["created_at"] = datetime.now().isoformat()
-
-            # Always update last_used when validated
-            values["last_used"] = datetime.now().isoformat()
+            if values.get("last_used") is None:
+                values["last_used"] = datetime.now().isoformat()
 
         return values
+
+    def mark_used(self) -> None:
+        """Update ``last_used`` to the current time.
+
+        Call this from the *real* load-to-use path. Don't call it from
+        validation, listing, or any other read-only probe.
+        """
+        self.last_used = datetime.now().isoformat()
 
     model_config = {
         "validate_assignment": True,  # Validate when attributes are assigned

--- a/src/tui/styles/main.tcss
+++ b/src/tui/styles/main.tcss
@@ -171,14 +171,14 @@ Footer {
     padding: 1;
 }
 
-#dialog-title {
+.dialog-title {
     text-style: bold;
     color: $accent;
     text-align: center;
     margin-bottom: 1;
 }
 
-#dialog-buttons {
+.dialog-buttons {
     height: 3;
     dock: bottom;
     align: center middle;

--- a/src/tui/utils/graceful_degradation.py
+++ b/src/tui/utils/graceful_degradation.py
@@ -119,7 +119,7 @@ class GracefulDegradation:
             "timestamp": _time.time(),
         }
 
-        self.app.notify(
+        self.app.log_notification(
             f"Feature '{feature_name}' disabled due to error: {error_message}",
             severity="warning",
         )
@@ -139,7 +139,7 @@ class GracefulDegradation:
             if feature_name in self.degradation_history:
                 del self.degradation_history[feature_name]
 
-            self.app.notify(
+            self.app.log_notification(
                 f"Feature '{feature_name}' has been reset and will be available on next use",
                 severity="info",
             )

--- a/src/tui/widgets/virtual_device_table.py
+++ b/src/tui/widgets/virtual_device_table.py
@@ -192,38 +192,47 @@ class VirtualDeviceTable(DataTable):
         """
         Update the viewport to show rows starting from new_start.
 
+        Cursor restoration is keyed on the *absolute index* of the selected
+        device into ``virtual_rows`` (not the on-screen row index, which
+        becomes stale after the shift). DataTable.rows is an OrderedDict
+        keyed by RowKey, so iterating it like a sequence and subscripting
+        row[0] is the bug we replaced.
+
         Args:
             new_start: New starting index for visible rows
         """
-        # Ensure new_start is within valid range
         max_start = max(0, len(self.virtual_rows) - self.visible_count)
         new_start = max(0, min(max_start, new_start))
 
-        if new_start != self.visible_start:
-            # Save current cursor position relative to visible rows
-            current_key = None
-            cursor_row = getattr(self, "cursor_row", None)
+        if new_start == self.visible_start:
+            return
 
-            if cursor_row is not None:
-                row_index = cursor_row
-                row_count = getattr(self, "row_count", 0)
-                if 0 <= row_index < row_count:
-                    try:
-                        current_key = self.get_row_at(row_index)[0]
-                    except (IndexError, AttributeError):
-                        current_key = None
+        cursor_row = getattr(self, "cursor_row", None)
+        absolute_index: int | None = None
+        if cursor_row is not None and 0 <= cursor_row < self.visible_count:
+            candidate = self.visible_start + cursor_row
+            if 0 <= candidate < len(self.virtual_rows):
+                absolute_index = candidate
 
-            # Update visible range and re-render
-            self.visible_start = new_start
-            self._render_visible_rows()
+        self.visible_start = new_start
+        self._render_visible_rows()
 
-            # Restore cursor position if possible
-            if current_key is not None and hasattr(self, "cursor_row"):
-                rows = getattr(self, "rows", [])
-                for i, row in enumerate(rows):
-                    try:
-                        if row and row[0] == current_key:
-                            self.cursor_row = i
-                            break
-                    except (IndexError, TypeError):
-                        continue
+        if absolute_index is None:
+            return
+
+        on_screen = absolute_index - self.visible_start
+        if 0 <= on_screen < min(self.visible_count, len(self.virtual_rows) - self.visible_start):
+            target = on_screen
+        else:
+            # Selected device scrolled out of the new viewport.
+            target = 0
+
+        try:
+            self.move_cursor(row=target)
+        except Exception:
+            # Older Textual versions may not expose move_cursor — fall back
+            # to direct assignment, which is allowed at the Reactive level.
+            try:
+                self.cursor_row = target
+            except Exception:
+                pass

--- a/src/tui/widgets/virtual_device_table.py
+++ b/src/tui/widgets/virtual_device_table.py
@@ -59,6 +59,22 @@ class VirtualDeviceTable(DataTable):
         This is the key optimization for handling large device lists.
         """
         self.clear()
+
+        if not self.virtual_rows:
+            try:
+                self.add_row(
+                    "ℹ️",
+                    "—",
+                    "No PCIe devices found — verify Linux + lspci access",
+                    "—",
+                    "—",
+                    "—",
+                    key="__empty_state__",
+                )
+            except Exception:
+                pass
+            return
+
         end = min(self.visible_start + self.visible_count, len(self.virtual_rows))
 
         for i in range(self.visible_start, end):

--- a/src/tui/widgets/virtual_device_table.py
+++ b/src/tui/widgets/virtual_device_table.py
@@ -72,6 +72,8 @@ class VirtualDeviceTable(DataTable):
                     key="__empty_state__",
                 )
             except Exception:
+                # Empty-state row is decorative; a missing widget should
+                # not break the rest of the redraw.
                 pass
             return
 
@@ -235,4 +237,6 @@ class VirtualDeviceTable(DataTable):
             try:
                 self.cursor_row = target
             except Exception:
+                # Cursor restoration is best-effort; if the Textual version
+                # rejects both APIs, the redraw still completes correctly.
                 pass

--- a/tests/tui/test_app_state_subscribe.py
+++ b/tests/tui/test_app_state_subscribe.py
@@ -1,0 +1,51 @@
+"""T6: `AppState.update_state` must not expose the live state dict.
+
+Subscribers previously received the live `self._state`, so any subscriber
+that triggered a re-entrant update or mutated the dict could corrupt the
+iteration. Verify they now receive a copy.
+"""
+
+from pcileechfwgenerator.tui.core.app_state import AppState
+
+
+def test_subscriber_receives_independent_copy():
+    state = AppState()
+    captured: dict = {}
+
+    def cb(old, new):
+        captured["new"] = new
+        # Try to mutate the snapshot — must not affect the live store.
+        new["devices"] = "mutated-by-subscriber"
+
+    state.subscribe(cb)
+    state.set_devices(["a", "b"])
+
+    assert captured["new"] != state.get_state("devices")
+    assert state.get_state("devices") == ["a", "b"]
+
+
+def test_reentrant_update_does_not_corrupt_iteration():
+    """A subscriber that triggers update_state mid-notification must not
+    cause the outer iteration to misfire."""
+    state = AppState()
+    calls: list[str] = []
+
+    def first(_old, _new):
+        calls.append("first")
+        # Re-entrant call inside iteration — would explode if the
+        # subscriber list weren't snapshotted and the state weren't copied.
+        if "reentered" not in calls:
+            calls.append("reentered")
+            state.set_selected_device("dev-1")
+
+    def second(_old, _new):
+        calls.append("second")
+
+    state.subscribe(first)
+    state.subscribe(second)
+    state.set_devices(["a"])
+
+    # Both subscribers ran for the outer update, and the inner update
+    # delivered to both as well.
+    assert calls.count("first") >= 2
+    assert calls.count("second") >= 2

--- a/tests/tui/test_background_monitor.py
+++ b/tests/tui/test_background_monitor.py
@@ -13,8 +13,26 @@ import pytest
 from pcileechfwgenerator.tui.core.background_monitor import BackgroundMonitor
 
 
-def _make_device(bdf: str, driver: str = "vfio-pci", is_suitable: bool = True):
-    return SimpleNamespace(bdf=bdf, driver=driver, is_suitable=is_suitable)
+def _make_device(
+    bdf: str,
+    driver: str = "vfio-pci",
+    is_suitable: bool = True,
+    vendor_name: str = "Acme",
+    device_name: str = "Widget",
+    iommu_group: str = "0",
+    suitability_score: float = 1.0,
+    status_indicator: str = "✅",
+):
+    return SimpleNamespace(
+        bdf=bdf,
+        driver=driver,
+        is_suitable=is_suitable,
+        vendor_name=vendor_name,
+        device_name=device_name,
+        iommu_group=iommu_group,
+        suitability_score=suitability_score,
+        status_indicator=status_indicator,
+    )
 
 
 def _make_app(devices):
@@ -62,11 +80,33 @@ async def test_monitor_skips_update_when_device_signature_unchanged():
     app = _make_app(devices)
     monitor = BackgroundMonitor(app)
 
-    monitor._last_status["devices_signature"] = (
-        ("0000:01:00.0", "vfio-pci", True),
-    )
+    # Prime the cache with the same fields the monitor will compute.
+    await _run_one_iteration(monitor)
+    app.app_state.set_devices.reset_mock()
+    app.ui_coordinator.apply_device_filters.reset_mock()
+    app.device_manager.scan_devices.return_value = devices
+    monitor._running = True
 
     await _run_one_iteration(monitor)
 
     app.app_state.set_devices.assert_not_called()
     app.ui_coordinator.apply_device_filters.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_monitor_detects_rendered_field_changes():
+    """A name change with same bdf/driver/is_suitable must still re-render."""
+    initial = [_make_device("0000:01:00.0", vendor_name="OldName")]
+    app = _make_app(initial)
+    monitor = BackgroundMonitor(app)
+
+    await _run_one_iteration(monitor)
+    app.app_state.set_devices.reset_mock()
+
+    updated = [_make_device("0000:01:00.0", vendor_name="NewName")]
+    app.device_manager.scan_devices.return_value = updated
+    monitor._running = True
+
+    await _run_one_iteration(monitor)
+
+    app.app_state.set_devices.assert_called_once_with(updated)

--- a/tests/tui/test_background_monitor.py
+++ b/tests/tui/test_background_monitor.py
@@ -1,0 +1,72 @@
+"""Regression tests for `BackgroundMonitor._monitor_device_changes`.
+
+T5 from `docs/plans/tui-correctness-pass.md`: previously the monitor wrote
+to `app._devices`, which the reactive/filter chain does not observe. Fixed
+to push through `app_state.set_devices(...)` and re-run the filter pipeline.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pcileechfwgenerator.tui.core.background_monitor import BackgroundMonitor
+
+
+def _make_device(bdf: str, driver: str = "vfio-pci", is_suitable: bool = True):
+    return SimpleNamespace(bdf=bdf, driver=driver, is_suitable=is_suitable)
+
+
+def _make_app(devices):
+    app = MagicMock()
+    app.device_manager.scan_devices = AsyncMock(return_value=devices)
+    app.app_state = MagicMock()
+    app.ui_coordinator = MagicMock()
+    return app
+
+
+async def _run_one_iteration(monitor: BackgroundMonitor) -> None:
+    """Drive `_monitor_device_changes` for exactly one loop iteration.
+
+    The loop's `await asyncio.sleep(interval)` is the only suspension point
+    between iterations; replacing it with a hook that flips `_running` lets
+    us return after a single tick without timing dependencies.
+    """
+
+    async def _stop(_interval):
+        monitor._running = False
+
+    with patch(
+        "pcileechfwgenerator.tui.core.background_monitor.asyncio.sleep",
+        side_effect=_stop,
+    ):
+        await monitor._monitor_device_changes(interval=0)
+
+
+@pytest.mark.asyncio
+async def test_monitor_pushes_devices_through_app_state():
+    devices = [_make_device("0000:01:00.0"), _make_device("0000:02:00.0")]
+    app = _make_app(devices)
+    monitor = BackgroundMonitor(app)
+
+    await _run_one_iteration(monitor)
+
+    app.app_state.set_devices.assert_called_once_with(devices)
+    app.ui_coordinator.apply_device_filters.assert_called_once()
+    app.ui_coordinator.update_device_table.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_monitor_skips_update_when_device_signature_unchanged():
+    devices = [_make_device("0000:01:00.0")]
+    app = _make_app(devices)
+    monitor = BackgroundMonitor(app)
+
+    monitor._last_status["devices_signature"] = (
+        ("0000:01:00.0", "vfio-pci", True),
+    )
+
+    await _run_one_iteration(monitor)
+
+    app.app_state.set_devices.assert_not_called()
+    app.ui_coordinator.apply_device_filters.assert_not_called()

--- a/tests/tui/test_build_orchestrator_local_build.py
+++ b/tests/tui/test_build_orchestrator_local_build.py
@@ -1,0 +1,56 @@
+"""T1: `BuildOrchestrator` must honor `BuildConfiguration.local_build`.
+
+Previously, `_validate_environment` walked a non-existent widget tree via
+`_get_app()`, which always returned `None`, so every build took the
+container path (and failed for non-root local-build users).
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pcileechfwgenerator.tui.core.build_orchestrator import BuildOrchestrator
+from pcileechfwgenerator.tui.models.config import BuildConfiguration
+
+
+@pytest.mark.asyncio
+async def test_local_build_skips_container_validation(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    orch = BuildOrchestrator()
+    orch._config = BuildConfiguration(local_build=True)
+
+    container = AsyncMock()
+    local = AsyncMock()
+    git = AsyncMock()
+    orch._validate_container_environment = container
+    orch._validate_local_environment = local
+    orch._ensure_git_repo = git
+
+    await orch._validate_environment()
+
+    container.assert_not_called()
+    local.assert_awaited_once_with(orch._config)
+
+
+@pytest.mark.asyncio
+async def test_container_build_runs_container_validation(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    orch = BuildOrchestrator()
+    orch._config = BuildConfiguration(local_build=False)
+
+    container = AsyncMock()
+    local = AsyncMock()
+    git = AsyncMock()
+    orch._validate_container_environment = container
+    orch._validate_local_environment = local
+    orch._ensure_git_repo = git
+
+    await orch._validate_environment()
+
+    container.assert_awaited_once()
+    local.assert_not_called()
+
+
+def test_get_app_is_removed():
+    """The widget-walking helper is the root cause; it must not return."""
+    assert not hasattr(BuildOrchestrator, "_get_app")

--- a/tests/tui/test_configuration_dialog_types.py
+++ b/tests/tui/test_configuration_dialog_types.py
@@ -1,0 +1,129 @@
+"""T12: ConfigurationDialog must preserve types across save/load.
+
+Old dialog rendered every value as Input(str(value)) and returned raw
+strings on save. Dict/list values came back as repr strings; saves
+silently failed downstream. Verify the new typed save:
+  - dict survives a round-trip
+  - list survives a round-trip
+  - bool stays bool
+  - int/float parse cleanly
+  - invalid int surfaces an error and skips dismiss
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from pcileechfwgenerator.tui.dialogs.configuration import ConfigurationDialog
+
+
+@pytest.fixture
+def patch_app(monkeypatch):
+    holder: dict = {}
+    monkeypatch.setattr(
+        ConfigurationDialog,
+        "app",
+        property(lambda self: holder["app"]),
+    )
+    return holder
+
+
+def _make_event(button_id: str):
+    btn = SimpleNamespace(id=button_id)
+    return SimpleNamespace(button=btn)
+
+
+def _bare_dialog(initial):
+    d = ConfigurationDialog.__new__(ConfigurationDialog)
+    # Skip Textual reactives (title is reactive on Screen); set via __dict__.
+    object.__setattr__(d, "config", dict(initial))
+    d.dismiss = MagicMock()
+    return d
+
+
+@pytest.mark.asyncio
+async def test_dict_round_trips_through_json(patch_app):
+    initial = {"custom_parameters": {"foo": 1, "bar": "baz"}}
+    d = _bare_dialog(initial)
+    patch_app["app"] = MagicMock()
+
+    # query_one returns a widget whose .value is the JSON the user typed.
+    widget = SimpleNamespace(value=json.dumps({"foo": 1, "bar": "baz"}))
+    d.query_one = MagicMock(return_value=widget)
+
+    await d.on_button_pressed(_make_event("save-config"))
+
+    d.dismiss.assert_called_once()
+    saved = d.dismiss.call_args[0][0]
+    assert saved["custom_parameters"] == {"foo": 1, "bar": "baz"}
+
+
+@pytest.mark.asyncio
+async def test_list_round_trips_through_json(patch_app):
+    initial = {"compatibility_overrides": ["a", "b"]}
+    d = _bare_dialog(initial)
+    patch_app["app"] = MagicMock()
+    widget = SimpleNamespace(value=json.dumps(["a", "b", "c"]))
+    d.query_one = MagicMock(return_value=widget)
+
+    await d.on_button_pressed(_make_event("save-config"))
+
+    saved = d.dismiss.call_args[0][0]
+    assert saved["compatibility_overrides"] == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_bool_preserved(patch_app):
+    initial = {"debug_mode": False}
+    d = _bare_dialog(initial)
+    patch_app["app"] = MagicMock()
+    widget = SimpleNamespace(value=True)  # Checkbox returns bool
+    d.query_one = MagicMock(return_value=widget)
+
+    await d.on_button_pressed(_make_event("save-config"))
+
+    saved = d.dismiss.call_args[0][0]
+    assert saved["debug_mode"] is True
+
+
+@pytest.mark.asyncio
+async def test_int_parses_cleanly(patch_app):
+    initial = {"profile_duration": 30.0}
+    d = _bare_dialog(initial)
+    patch_app["app"] = MagicMock()
+    widget = SimpleNamespace(value="45.5")
+    d.query_one = MagicMock(return_value=widget)
+
+    await d.on_button_pressed(_make_event("save-config"))
+
+    saved = d.dismiss.call_args[0][0]
+    assert saved["profile_duration"] == 45.5
+
+
+@pytest.mark.asyncio
+async def test_invalid_number_surfaces_error_and_skips_dismiss(patch_app):
+    initial = {"profile_duration": 30.0}
+    d = _bare_dialog(initial)
+    app = MagicMock()
+    patch_app["app"] = app
+    widget = SimpleNamespace(value="not-a-number")
+    d.query_one = MagicMock(return_value=widget)
+
+    await d.on_button_pressed(_make_event("save-config"))
+
+    d.dismiss.assert_not_called()
+    app.log_notification.assert_called()
+    severities = [c.kwargs.get("severity") for c in app.log_notification.call_args_list]
+    assert "error" in severities
+
+
+@pytest.mark.asyncio
+async def test_cancel_dismisses_none(patch_app):
+    d = _bare_dialog({"x": 1})
+    patch_app["app"] = MagicMock()
+
+    await d.on_button_pressed(_make_event("cancel-config"))
+
+    d.dismiss.assert_called_once_with(None)

--- a/tests/tui/test_dialogs_base.py
+++ b/tests/tui/test_dialogs_base.py
@@ -1,0 +1,62 @@
+"""Tests for the BaseDialog escape-to-dismiss contract.
+
+These tests use Textual's Pilot harness to verify that dialogs dismiss
+with the documented default value when the user presses Escape.
+"""
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button
+
+from pcileechfwgenerator.tui.dialogs.confirmation import ConfirmationDialog
+from pcileechfwgenerator.tui.dialogs.file_path_input import FilePathInputDialog
+from pcileechfwgenerator.tui.dialogs.help_dialog import HelpDialog
+
+
+class _DismissCapture:
+    def __init__(self) -> None:
+        self.value = "<unset>"
+
+    def __call__(self, value) -> None:
+        self.value = value
+
+
+def _harness(dialog):
+    """Build a tiny App that pushes the given dialog on mount."""
+    captured = _DismissCapture()
+
+    class _Harness(App):
+        def compose(self) -> ComposeResult:  # pragma: no cover - trivial
+            yield Button("noop")
+
+        async def on_mount(self) -> None:
+            await self.push_screen(dialog, captured)
+
+    return _Harness(), captured
+
+
+@pytest.mark.asyncio
+async def test_confirmation_dialog_escape_returns_false():
+    app, captured = _harness(ConfirmationDialog("Title", "msg"))
+    async with app.run_test() as pilot:
+        await pilot.press("escape")
+        await pilot.pause()
+    assert captured.value is False
+
+
+@pytest.mark.asyncio
+async def test_help_dialog_escape_returns_true():
+    app, captured = _harness(HelpDialog())
+    async with app.run_test() as pilot:
+        await pilot.press("escape")
+        await pilot.pause()
+    assert captured.value is True
+
+
+@pytest.mark.asyncio
+async def test_file_path_input_dialog_escape_returns_none():
+    app, captured = _harness(FilePathInputDialog("Pick a path"))
+    async with app.run_test() as pilot:
+        await pilot.press("escape")
+        await pilot.pause()
+    assert captured.value is None

--- a/tests/tui/test_donor_template_notify_once.py
+++ b/tests/tui/test_donor_template_notify_once.py
@@ -1,0 +1,54 @@
+"""T8: success notification fires exactly once.
+
+Both the coordinator's `generate_donor_template` and main's
+`_generate_donor_template` emitted the same "Donor template saved" line.
+After the dedup, only the coordinator's notification carries the result;
+main may add a *different* hint line.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pcileechfwgenerator.tui.main import PCILeechTUI
+
+
+@pytest.mark.asyncio
+async def test_success_notification_does_not_duplicate():
+    app = PCILeechTUI.__new__(PCILeechTUI)
+    app.ui_coordinator = MagicMock()
+    app.ui_coordinator.generate_donor_template = AsyncMock(
+        return_value=Path("donor_info_template.json")
+    )
+    app.log_notification = MagicMock()
+
+    await PCILeechTUI._generate_donor_template(app)
+
+    saved_msgs = [
+        c.args[0]
+        for c in app.log_notification.call_args_list
+        if "saved" in c.args[0].lower()
+    ]
+    # The "saved" line lives in the coordinator — which is mocked here, so
+    # zero "saved" calls on main's log_notification means no duplicate.
+    assert saved_msgs == []
+    # The hint still fires.
+    hint_msgs = [
+        c.args[0]
+        for c in app.log_notification.call_args_list
+        if "Fill in" in c.args[0]
+    ]
+    assert len(hint_msgs) == 1
+
+
+@pytest.mark.asyncio
+async def test_failure_emits_no_main_side_hint():
+    app = PCILeechTUI.__new__(PCILeechTUI)
+    app.ui_coordinator = MagicMock()
+    app.ui_coordinator.generate_donor_template = AsyncMock(return_value=None)
+    app.log_notification = MagicMock()
+
+    await PCILeechTUI._generate_donor_template(app)
+
+    app.log_notification.assert_not_called()

--- a/tests/tui/test_executor_lifecycle.py
+++ b/tests/tui/test_executor_lifecycle.py
@@ -1,0 +1,63 @@
+"""T10: ThreadPoolExecutor must be build-scoped.
+
+Previously a single ThreadPoolExecutor was instantiated in __init__ and
+shutdown() ran in the start_build finally. A late _update_resource_usage
+tick after shutdown raised RuntimeError; subsequent builds couldn't reuse
+the orchestrator. Verify the new lifecycle:
+  - executor is None at rest
+  - _update_resource_usage is a no-op when executor is None
+  - two sequential builds on one orchestrator don't crash
+"""
+
+
+import pytest
+
+from pcileechfwgenerator.tui.core.build_orchestrator import BuildOrchestrator
+from pcileechfwgenerator.tui.models.config import BuildConfiguration
+from pcileechfwgenerator.tui.models.device import PCIDevice
+from pcileechfwgenerator.tui.models.progress import (
+    BuildProgress,
+    BuildStage,
+)
+
+
+def test_executor_starts_unset():
+    orch = BuildOrchestrator()
+    assert orch._executor is None
+
+
+@pytest.mark.asyncio
+async def test_update_resource_usage_noop_without_executor():
+    orch = BuildOrchestrator()
+    orch._current_progress = BuildProgress(
+        stage=BuildStage.ENVIRONMENT_VALIDATION,
+        completion_percent=0.0,
+        current_operation="x",
+    )
+    # No executor — must not raise.
+    await orch._update_resource_usage()
+
+
+@pytest.mark.asyncio
+async def test_two_sequential_builds_share_orchestrator(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    orch = BuildOrchestrator()
+
+    # Replace the heavy work with a no-op stage list.
+    orch._create_build_stages = lambda dev, cfg: []  # type: ignore[assignment]
+
+    device = PCIDevice(
+        bdf="0000:01:00.0",
+        vendor_id="abcd",
+        device_id="1234",
+        vendor_name="x",
+        device_name="y",
+        device_class="0x000000",
+    )
+    config = BuildConfiguration(local_build=True)
+
+    assert await orch.start_build(device, config) is True
+    assert orch._executor is None  # released
+
+    assert await orch.start_build(device, config) is True
+    assert orch._executor is None

--- a/tests/tui/test_handle_build_start_donor_cancel.py
+++ b/tests/tui/test_handle_build_start_donor_cancel.py
@@ -1,0 +1,51 @@
+"""T2: `handle_build_start` must honor a False return from `_validate_donor_module`.
+
+Previously the coordinator discarded the validator's return value and started
+the build even when the user cancelled the install confirmation dialog.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pcileechfwgenerator.tui.core.ui_coordinator import UICoordinator
+
+
+def _make_app():
+    app = MagicMock()
+    app.selected_device = SimpleNamespace(bdf="0000:01:00.0", is_suitable=True)
+    app.current_config = SimpleNamespace(donor_dump=True, local_build=False)
+    app.build_orchestrator = MagicMock()
+    app.build_orchestrator.is_building.return_value = False
+    app.build_orchestrator.start_build = AsyncMock(return_value=True)
+    app.device_manager = MagicMock()
+    app.config_manager = MagicMock()
+    app.status_monitor = MagicMock()
+    # query_one returns a widget mock with a settable .disabled
+    app.query_one.return_value = MagicMock(disabled=False)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_donor_validation_cancel_aborts_build():
+    app = _make_app()
+    coord = UICoordinator(app)
+    coord._validate_donor_module = AsyncMock(return_value=False)
+
+    await coord.handle_build_start()
+
+    app.build_orchestrator.start_build.assert_not_called()
+    # The cancel notice fires; we don't pin the exact text.
+    assert app.notify.called
+
+
+@pytest.mark.asyncio
+async def test_donor_validation_pass_starts_build():
+    app = _make_app()
+    coord = UICoordinator(app)
+    coord._validate_donor_module = AsyncMock(return_value=True)
+
+    await coord.handle_build_start()
+
+    app.build_orchestrator.start_build.assert_awaited_once()

--- a/tests/tui/test_handle_build_start_donor_cancel.py
+++ b/tests/tui/test_handle_build_start_donor_cancel.py
@@ -36,8 +36,8 @@ async def test_donor_validation_cancel_aborts_build():
     await coord.handle_build_start()
 
     app.build_orchestrator.start_build.assert_not_called()
-    # The cancel notice fires; we don't pin the exact text.
-    assert app.notify.called
+    # The cancel notice fires through the persistent log; don't pin text.
+    assert app.log_notification.called or app.notify.called
 
 
 @pytest.mark.asyncio

--- a/tests/tui/test_last_used_preserved.py
+++ b/tests/tui/test_last_used_preserved.py
@@ -32,6 +32,32 @@ def test_mark_used_updates_timestamp():
     assert cfg.last_used != "2025-01-01T00:00:00"
 
 
+def test_export_profile_does_not_touch_source_mtime(tmp_path, monkeypatch):
+    """export_profile must be read-only on the source file."""
+    from pcileechfwgenerator.tui.core import config_manager as cm_mod
+    from pcileechfwgenerator.tui.core.config_manager import ConfigManager
+
+    monkeypatch.setattr(cm_mod, "CACHE_DIR", tmp_path)
+    mgr = ConfigManager()
+    mgr.config_dir = tmp_path / "profiles"
+    mgr.config_dir.mkdir(parents=True, exist_ok=True)
+
+    cfg = BuildConfiguration(name="probe", last_used="2025-01-01T00:00:00")
+    source = mgr.config_dir / "probe.json"
+    source.write_text(json.dumps(cfg.dict()))
+    source_mtime_before = source.stat().st_mtime
+    source_text_before = source.read_text()
+
+    target = tmp_path / "exported.json"
+    time.sleep(0.05)
+    ok = mgr.export_profile("probe", target)
+
+    assert ok is True
+    assert target.exists()
+    assert source.stat().st_mtime == source_mtime_before
+    assert source.read_text() == source_text_before
+
+
 def test_validate_config_does_not_touch_file_mtime(tmp_path, monkeypatch):
     """validate_config must be read-only — no save-back side effect."""
     from pcileechfwgenerator.tui.core import config_manager as cm_mod

--- a/tests/tui/test_last_used_preserved.py
+++ b/tests/tui/test_last_used_preserved.py
@@ -1,0 +1,55 @@
+"""T13: `last_used` must not be clobbered on every read.
+
+The set_timestamps validator used to unconditionally rewrite last_used on
+every BuildConfiguration(...) call. validate_config + load_profile each
+instantiate the model purely as a schema check, so reading a profile
+mutated the on-disk timestamp.
+"""
+
+import json
+import time
+
+from pcileechfwgenerator.tui.models.configuration import BuildConfiguration
+
+
+def test_existing_last_used_is_preserved():
+    cfg = BuildConfiguration(last_used="2025-01-01T00:00:00", name="x")
+    assert cfg.last_used == "2025-01-01T00:00:00"
+
+
+def test_missing_last_used_is_populated_once():
+    cfg = BuildConfiguration(name="x")
+    ts = cfg.last_used
+    assert ts is not None and ts != ""
+    # Round-trip preserves the original timestamp.
+    cfg2 = BuildConfiguration(**cfg.dict())
+    assert cfg2.last_used == ts
+
+
+def test_mark_used_updates_timestamp():
+    cfg = BuildConfiguration(last_used="2025-01-01T00:00:00", name="x")
+    cfg.mark_used()
+    assert cfg.last_used != "2025-01-01T00:00:00"
+
+
+def test_validate_config_does_not_touch_file_mtime(tmp_path, monkeypatch):
+    """validate_config must be read-only — no save-back side effect."""
+    from pcileechfwgenerator.tui.core import config_manager as cm_mod
+    from pcileechfwgenerator.tui.core.config_manager import ConfigManager
+
+    monkeypatch.setattr(cm_mod, "CACHE_DIR", tmp_path)
+    mgr = ConfigManager()
+    mgr.config_dir = tmp_path / "profiles"
+    mgr.config_dir.mkdir(parents=True, exist_ok=True)
+
+    cfg = BuildConfiguration(name="probe", last_used="2025-01-01T00:00:00")
+    profile_path = mgr.config_dir / "probe.json"
+    profile_path.write_text(json.dumps(cfg.dict()))
+    mtime_before = profile_path.stat().st_mtime
+
+    time.sleep(0.05)
+    issues = mgr.validate_config(cfg)
+    mtime_after = profile_path.stat().st_mtime
+
+    assert issues == [] or all(isinstance(s, str) for s in issues)
+    assert mtime_after == mtime_before

--- a/tests/tui/test_log_notification.py
+++ b/tests/tui/test_log_notification.py
@@ -1,0 +1,45 @@
+"""T7: persistent-log behaviour moved out from App.notify.
+
+The override previously hijacked Textual's `notify`, so toasts never
+appeared and any caller passing an unknown severity was silently shadowed.
+After the rename, `log_notification` writes to `#notification-log` and
+Textual's `notify` is left intact.
+"""
+
+from unittest.mock import MagicMock
+
+
+from pcileechfwgenerator.tui.main import PCILeechTUI
+
+
+def test_log_notification_writes_to_richlog():
+    """log_notification should append a timestamped line to the RichLog."""
+    app = PCILeechTUI.__new__(PCILeechTUI)
+    log_widget = MagicMock()
+    app.query_one = MagicMock(return_value=log_widget)
+
+    app.log_notification("hello", severity="success")
+
+    log_widget.write.assert_called_once()
+    line = log_widget.write.call_args[0][0]
+    assert "hello" in line
+    assert "SUCCESS" in line
+
+
+def test_notify_is_textual_builtin_not_overridden():
+    """PCILeechTUI must not redefine notify (Textual owns it)."""
+    from textual.app import App
+
+    # The class-level method should be inherited from textual.app.App,
+    # not redefined on PCILeechTUI itself.
+    assert "notify" not in PCILeechTUI.__dict__
+    assert PCILeechTUI.notify is App.notify
+
+
+def test_log_notification_swallows_errors():
+    """log_notification must never raise — it's a best-effort path."""
+    app = PCILeechTUI.__new__(PCILeechTUI)
+    app.query_one = MagicMock(side_effect=RuntimeError("no widget"))
+
+    # Should not propagate.
+    app.log_notification("anything")

--- a/tests/tui/test_profile_manager_dialog.py
+++ b/tests/tui/test_profile_manager_dialog.py
@@ -1,0 +1,147 @@
+"""T4: `ProfileManagerDialog` button methods.
+
+The dialog's button handlers called five methods that didn't exist; every
+press raised AttributeError (swallowed silently). These tests pin the new
+behaviours: load / delete / export / import / create_new.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pcileechfwgenerator.tui.dialogs.profile_manager import ProfileManagerDialog
+
+
+@pytest.fixture
+def patch_dialog_app(monkeypatch):
+    """Replace Screen.app property with a settable attribute for tests."""
+    holder: dict = {}
+
+    monkeypatch.setattr(
+        ProfileManagerDialog,
+        "app",
+        property(lambda self: holder["app"]),
+    )
+    return holder
+
+
+def _make_dialog(holder, selected_name: str | None = "profile-a"):
+    cm = MagicMock()
+    cm.list_profiles.return_value = [
+        {"name": "profile-a", "description": "", "last_used": "2025-01-01"},
+        {"name": "profile-b", "description": "", "last_used": "2024-12-31"},
+    ]
+    dialog = ProfileManagerDialog.__new__(ProfileManagerDialog)
+    dialog.config_manager = cm
+    dialog.profiles = cm.list_profiles.return_value
+    dialog._refresh_profiles = MagicMock()
+    dialog.dismiss = MagicMock()
+    dialog._selected_profile_name = MagicMock(return_value=selected_name)
+
+    app = MagicMock()
+    app.push_screen_wait = AsyncMock()
+    app.notify = MagicMock()
+    app.current_config = SimpleNamespace()
+    holder["app"] = app
+    return dialog, app, cm
+
+
+@pytest.mark.asyncio
+async def test_load_dismisses_with_selected_name(patch_dialog_app):
+    dialog, _, _ = _make_dialog(patch_dialog_app, "profile-a")
+    await dialog._load_selected_profile()
+    dialog.dismiss.assert_called_once_with("profile-a")
+
+
+@pytest.mark.asyncio
+async def test_load_no_selection_notifies_error(patch_dialog_app):
+    dialog, app, _ = _make_dialog(patch_dialog_app, selected_name=None)
+    await dialog._load_selected_profile()
+    dialog.dismiss.assert_not_called()
+    app.notify.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_confirms_then_calls_config_manager(patch_dialog_app):
+    dialog, app, cm = _make_dialog(patch_dialog_app, "profile-a")
+    app.push_screen_wait.return_value = True
+    cm.delete_profile.return_value = True
+
+    await dialog._delete_selected_profile()
+
+    cm.delete_profile.assert_called_once_with("profile-a")
+    dialog._refresh_profiles.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_cancel_skips_delete(patch_dialog_app):
+    dialog, app, cm = _make_dialog(patch_dialog_app, "profile-a")
+    app.push_screen_wait.return_value = False
+
+    await dialog._delete_selected_profile()
+
+    cm.delete_profile.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_export_prompts_then_calls_export_profile(patch_dialog_app, tmp_path):
+    dialog, app, cm = _make_dialog(patch_dialog_app, "profile-a")
+    target = tmp_path / "out.json"
+    app.push_screen_wait.return_value = str(target)
+    cm.export_profile.return_value = True
+
+    await dialog._export_selected_profile()
+
+    cm.export_profile.assert_called_once_with("profile-a", Path(str(target)))
+
+
+@pytest.mark.asyncio
+async def test_import_prompts_then_refreshes(patch_dialog_app, tmp_path):
+    dialog, app, cm = _make_dialog(patch_dialog_app)
+    target = tmp_path / "in.json"
+    app.push_screen_wait.return_value = str(target)
+    cm.import_profile.return_value = "imported-name"
+
+    await dialog._import_profile()
+
+    cm.import_profile.assert_called_once_with(Path(str(target)))
+    dialog._refresh_profiles.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_new_saves_current_config(patch_dialog_app):
+    dialog, app, cm = _make_dialog(patch_dialog_app)
+    app.push_screen_wait.return_value = "fresh-profile"
+    cm.save_profile.return_value = True
+
+    await dialog._create_new_profile()
+
+    cm.save_profile.assert_called_once_with("fresh-profile", app.current_config)
+    dialog._refresh_profiles.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_new_blank_name_skips_save(patch_dialog_app):
+    dialog, app, cm = _make_dialog(patch_dialog_app)
+    app.push_screen_wait.return_value = None
+
+    await dialog._create_new_profile()
+
+    cm.save_profile.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_export_failure_notifies_error(patch_dialog_app, tmp_path):
+    dialog, app, cm = _make_dialog(patch_dialog_app, "profile-a")
+    app.push_screen_wait.return_value = str(tmp_path / "out.json")
+    cm.export_profile.side_effect = RuntimeError("boom")
+
+    await dialog._export_selected_profile()
+
+    # Last notify call records the failure with severity=error.
+    severities = [
+        c.kwargs.get("severity") for c in app.notify.call_args_list
+    ]
+    assert "error" in severities

--- a/tests/tui/test_profile_manager_dialog.py
+++ b/tests/tui/test_profile_manager_dialog.py
@@ -42,7 +42,7 @@ def _make_dialog(holder, selected_name: str | None = "profile-a"):
 
     app = MagicMock()
     app.push_screen_wait = AsyncMock()
-    app.notify = MagicMock()
+    app.log_notification = MagicMock()
     app.current_config = SimpleNamespace()
     holder["app"] = app
     return dialog, app, cm
@@ -60,7 +60,7 @@ async def test_load_no_selection_notifies_error(patch_dialog_app):
     dialog, app, _ = _make_dialog(patch_dialog_app, selected_name=None)
     await dialog._load_selected_profile()
     dialog.dismiss.assert_not_called()
-    app.notify.assert_called()
+    app.log_notification.assert_called()
 
 
 @pytest.mark.asyncio
@@ -140,8 +140,7 @@ async def test_export_failure_notifies_error(patch_dialog_app, tmp_path):
 
     await dialog._export_selected_profile()
 
-    # Last notify call records the failure with severity=error.
     severities = [
-        c.kwargs.get("severity") for c in app.notify.call_args_list
+        c.kwargs.get("severity") for c in app.log_notification.call_args_list
     ]
     assert "error" in severities

--- a/tests/tui/test_row_selection.py
+++ b/tests/tui/test_row_selection.py
@@ -1,0 +1,84 @@
+"""T3: device row selection must extract the underlying RowKey value.
+
+The handler previously did `device.bdf == event.row_key`, which compared a
+plain str to Textual's `RowKey` wrapper. In some Textual versions that's
+always False, so `selected_device` stayed None and Start Build never
+enabled.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class _FakeRowKey:
+    """RowKey-like wrapper whose `__eq__` does NOT match plain strings.
+
+    Modelled on older Textual versions where the bug surfaced. Hard-rejecting
+    str comparison here lets the test catch any regression to direct compare.
+    """
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __eq__(self, other) -> bool:  # noqa: D401
+        return isinstance(other, _FakeRowKey) and other.value == self.value
+
+    def __hash__(self) -> int:
+        return hash(("_FakeRowKey", self.value))
+
+
+def _build_app_for(devices):
+    """Construct a PCILeechTUI bare enough for on_data_table_row_selected."""
+    from pcileechfwgenerator.tui.main import PCILeechTUI
+
+    app = PCILeechTUI.__new__(PCILeechTUI)  # skip __init__ — no Textual loop
+    app.app_state = MagicMock()
+
+    # filtered_devices is a computed property that reads from app_state and
+    # the device_filters property; stub the property at the class level for
+    # this test so we don't need a full AppState wiring.
+    PCILeechTUI._test_devices = devices  # type: ignore[attr-defined]
+    app.ui_coordinator = MagicMock()
+    app.ui_coordinator.handle_device_selection = AsyncMock()
+    return app
+
+
+@pytest.fixture
+def patch_filtered_devices(monkeypatch):
+    from pcileechfwgenerator.tui.main import PCILeechTUI
+
+    monkeypatch.setattr(
+        PCILeechTUI,
+        "filtered_devices",
+        property(lambda self: getattr(self, "_test_devices", [])),
+    )
+
+
+@pytest.mark.asyncio
+async def test_row_selected_matches_against_row_key_value(patch_filtered_devices):
+    from pcileechfwgenerator.tui.main import PCILeechTUI
+
+    dev = SimpleNamespace(bdf="0000:01:00.0", is_suitable=True)
+    app = _build_app_for([dev])
+
+    event = SimpleNamespace(row_key=_FakeRowKey("0000:01:00.0"))
+    await PCILeechTUI.on_data_table_row_selected(app, event)
+
+    app.app_state.set_selected_device.assert_called_once_with(dev)
+    app.ui_coordinator.handle_device_selection.assert_awaited_once_with(dev)
+
+
+@pytest.mark.asyncio
+async def test_row_selected_no_match_leaves_state_alone(patch_filtered_devices):
+    from pcileechfwgenerator.tui.main import PCILeechTUI
+
+    dev = SimpleNamespace(bdf="0000:02:00.0", is_suitable=True)
+    app = _build_app_for([dev])
+
+    event = SimpleNamespace(row_key=_FakeRowKey("0000:99:99.9"))
+    await PCILeechTUI.on_data_table_row_selected(app, event)
+
+    app.app_state.set_selected_device.assert_not_called()
+    app.ui_coordinator.handle_device_selection.assert_not_awaited()

--- a/tests/tui/test_run_shell_cancel.py
+++ b/tests/tui/test_run_shell_cancel.py
@@ -1,0 +1,67 @@
+"""T9: `_run_shell` must drain stdout+stderr concurrently and respect cancel.
+
+The old monitored path read only stdout via blocking `readline()` and never
+checked `_should_cancel`, so the Stop button was inert during a build that
+held its pipes open (typical for Vivado). Verify the new path:
+  1. Cancels a long-running child within ~2 seconds.
+  2. Times out idle readlines instead of blocking forever.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from pcileechfwgenerator.tui.core.build_orchestrator import (
+    READLINE_TIMEOUT_SEC,
+    BuildOrchestrator,
+)
+
+
+def test_readline_timeout_constant_is_module_level():
+    assert isinstance(READLINE_TIMEOUT_SEC, float)
+    assert 0 < READLINE_TIMEOUT_SEC <= 5
+
+
+@pytest.mark.asyncio
+async def test_cancel_mid_run_terminates_within_two_seconds():
+    """A long-sleeping child must die when _should_cancel is set."""
+    orch = BuildOrchestrator()
+
+    # Trip cancel after ~250ms (well inside the readline poll cadence).
+    async def _trip_cancel():
+        await asyncio.sleep(0.25)
+        orch._should_cancel = True
+
+    asyncio.create_task(_trip_cancel())
+
+    start = time.monotonic()
+    result = await orch._run_shell(
+        'python3 -c "import time; time.sleep(30)"',
+        monitor=True,
+    )
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 4.0, f"cancel took too long: {elapsed:.2f}s"
+    # process was killed — returncode is non-zero (negative on SIGTERM)
+    assert result.returncode != 0
+    assert orch._should_cancel is True
+
+
+@pytest.mark.asyncio
+async def test_process_that_closes_stdout_but_keeps_running_observed():
+    """If a child closes stdout but lingers, the loop must still observe
+    the exit (not hang on readline)."""
+    orch = BuildOrchestrator()
+    # Child: print then close stdout; exit ~0.5s later.
+    cmd = (
+        'python3 -c "import os,sys,time; '
+        'print(\'hello\'); sys.stdout.close(); os.close(1); time.sleep(0.5)"'
+    )
+
+    start = time.monotonic()
+    result = await orch._run_shell(cmd, monitor=True)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 5.0
+    assert result.returncode == 0

--- a/tests/tui/test_run_shell_cancel.py
+++ b/tests/tui/test_run_shell_cancel.py
@@ -54,9 +54,11 @@ async def test_process_that_closes_stdout_but_keeps_running_observed():
     the exit (not hang on readline)."""
     orch = BuildOrchestrator()
     # Child: print then close stdout; exit ~0.5s later.
+    # sys.stdout.close() already closes fd 1 — a subsequent os.close(1)
+    # raises OSError and would taint the return code. One close is enough.
     cmd = (
-        'python3 -c "import os,sys,time; '
-        'print(\'hello\'); sys.stdout.close(); os.close(1); time.sleep(0.5)"'
+        'python3 -c "import sys,time; '
+        'print(\'hello\'); sys.stdout.close(); time.sleep(0.5)"'
     )
 
     start = time.monotonic()

--- a/tests/tui/test_ui_coordinator.py
+++ b/tests/tui/test_ui_coordinator.py
@@ -1,6 +1,4 @@
-import asyncio
 import json
-from pathlib import Path
 
 import pytest
 
@@ -71,6 +69,10 @@ class DummyApp:
 
     def notify(self, *_args, **_kwargs):
         # no-op for tests
+        pass
+
+    def log_notification(self, *_args, **_kwargs):
+        # no-op — persistent notification stub for tests
         pass
 
     def _get_current_timestamp(self):

--- a/tests/tui/test_virtual_device_table_cursor.py
+++ b/tests/tui/test_virtual_device_table_cursor.py
@@ -1,0 +1,80 @@
+"""T14: viewport shift must restore cursor against the absolute index.
+
+DataTable.rows is an OrderedDict[RowKey, Row], not a list — the previous
+`row[0] == current_key` loop indexed into a RowKey object. Verify the new
+absolute-index restore.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from textual.app import App, ComposeResult
+
+from pcileechfwgenerator.tui.widgets.virtual_device_table import (
+    VirtualDeviceTable,
+)
+
+
+def _make_device(i: int):
+    return SimpleNamespace(
+        bdf=f"0000:{i:02x}:00.0",
+        vendor_name="v",
+        device_name="d",
+        driver=None,
+        iommu_group=str(i),
+        suitability_score=1.0,
+        is_suitable=True,
+        status_indicator="",
+    )
+
+
+class _Harness(App):
+    table: VirtualDeviceTable
+
+    def compose(self) -> ComposeResult:  # pragma: no cover
+        self.table = VirtualDeviceTable(id="dt")
+        yield self.table
+
+
+@pytest.mark.asyncio
+async def test_cursor_stays_on_selected_device_after_viewport_shift():
+    devices = [_make_device(i) for i in range(120)]
+    app = _Harness()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        table = app.table
+        table.set_data(devices)
+        await pilot.pause()
+
+        # Place cursor on absolute row 30 (within initial 0..49 viewport).
+        table.move_cursor(row=30)
+        await pilot.pause()
+
+        # Shift the viewport to start at 25 — absolute 30 is still visible.
+        table._update_viewport(25)
+        await pilot.pause()
+
+        assert table.visible_start == 25
+        # Cursor must follow the device: absolute 30 - new_start 25 = 5.
+        assert table.cursor_row == 5
+
+
+@pytest.mark.asyncio
+async def test_cursor_clamps_to_zero_when_selection_scrolls_out():
+    devices = [_make_device(i) for i in range(120)]
+    app = _Harness()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        table = app.table
+        table.set_data(devices)
+        await pilot.pause()
+
+        table.move_cursor(row=5)  # absolute row 5
+        await pilot.pause()
+
+        # Jump the viewport far away; absolute 5 is no longer visible.
+        table._update_viewport(70)
+        await pilot.pause()
+
+        assert table.visible_start == 70
+        assert table.cursor_row == 0

--- a/tests/tui/test_vivado_cmd_quoting.py
+++ b/tests/tui/test_vivado_cmd_quoting.py
@@ -1,0 +1,45 @@
+"""T11: spaced paths must survive the build command pipeline.
+
+Old code: build args were string-joined then `.split()` again, shredding
+any path with embedded spaces. Verify the new list[str] assembly + shlex
+quoting keeps the spaced path as a single shell argument.
+"""
+
+import shlex
+
+import pytest
+
+
+def test_shlex_join_preserves_spaced_path():
+    args = ["python3", "src/build.py", "--donor-info-file", "/tmp/foo bar/profile.json"]
+    joined = shlex.join(args)
+    # Round-trip through shlex.split must give the original list back.
+    assert shlex.split(joined) == args
+
+
+@pytest.mark.asyncio
+async def test_run_shell_quotes_list_args(monkeypatch):
+    """_run_shell, given a list[str], must pass a properly quoted string
+    to create_subprocess_shell — not a naive ' '.join."""
+    from pcileechfwgenerator.tui.core import build_orchestrator as bo
+    from pcileechfwgenerator.tui.core.build_orchestrator import BuildOrchestrator
+
+    captured = {}
+
+    class _FakeProc:
+        returncode = 0
+
+        async def communicate(self):
+            return (b"", b"")
+
+    async def fake_shell(cmd_str, **_kwargs):
+        captured["cmd_str"] = cmd_str
+        return _FakeProc()
+
+    monkeypatch.setattr(bo.asyncio, "create_subprocess_shell", fake_shell)
+
+    orch = BuildOrchestrator()
+    cmd = ["python3", "src/build.py", "--donor-info-file", "/tmp/foo bar/donor.json"]
+    await orch._run_shell(cmd, monitor=False)
+
+    assert shlex.split(captured["cmd_str"]) == cmd


### PR DESCRIPTION
## Summary

Implements the full 14-task plan in [`docs/plans/tui-correctness-pass.md`](docs/plans/tui-correctness-pass.md). One commit per task, each with a regression test under `tests/tui/`. Scope is bug fixes only — no refactors, no dead-code deletion (deferred to a separate pass).

| Task | Fix |
|---|---|
| T1 | `BuildOrchestrator._validate_environment` honors `local_build` via stored config instead of a no-op widget walk |
| T2 | `handle_build_start` aborts the build when `_validate_donor_module()` returns False |
| T3 | Device row selection compares `event.row_key.value` instead of the wrapper |
| T4 | `ProfileManagerDialog` implements `_load/_delete/_export/_import/_create_new_profile` (button presses no longer silently raise) |
| T5 | Background monitor pushes through `app_state.set_devices(...)` and uses a signature-based change detector; new `BaseDialog` extracted, dialog CSS scoped to classes |
| T6 | `AppState.update_state` passes shallow copies of old/new state to subscribers; subscriber list snapshotted before iteration |
| T7 | `App.notify` override renamed to `log_notification`; Textual's `notify` left intact for toasts; 74 callsites migrated |
| T8 | Donor template success notification fires once (coordinator owns it; main's duplicate removed) |
| T9 | `_run_shell` drains stdout+stderr concurrently with a `READLINE_TIMEOUT_SEC=1.0` poll, honors `_should_cancel`, terminate→kill on cancel |
| T10 | `ThreadPoolExecutor` is build-scoped; `_update_resource_usage` is a graceful no-op when the pool is gone |
| T11 | Vivado/container build args assembled as `list[str]` and `shlex.join`'d in `_run_shell` so spaced paths survive |
| T12 | `ConfigurationDialog` renders Checkbox for bools, JSON-encodes dict/list fields, parses numerics with error notify; main surfaces `from_dict` errors |
| T13 | `set_timestamps` validator only fills `last_used` when missing; new `mark_used()` is the explicit usage stamp; `validate_config` is read-only |
| T14 | `VirtualDeviceTable` viewport-shift cursor restore tracks the absolute index into `virtual_rows`; clamps to 0 when scrolled out |

## Test plan

- [x] `pytest tests/tui -q` — 81/81 pass (was 36 before this branch; +45 new regression tests)
- [ ] Manual smoke: launch the TUI, select a device, open Configuration / Profiles / Search dialogs, press Escape on each (BaseDialog binding), trigger a build, hit Stop mid-run (T9 cancel path).
- [ ] Confirm `local_build=True` config now takes the local path on a non-root host (T1).
- [ ] Confirm reading a profile no longer rewrites its `last_used` timestamp (`stat profiles/<name>.json` before/after).