### PR TITLE
fix(host-collect): pass config space as hex string to MSI-X parser (#612)

### DIFF
--- a/src/host_collect/collector.py
+++ b/src/host_collect/collector.py
@@ -52,7 +52,7 @@ class HostCollector:
 
             cfg_hex = cfg.hex()
             msix_info = self._parse_msix(cfg_hex)
-            
+
             # Extract device identifiers from config space
             device_ids = self._extract_device_ids(cfg)
 

--- a/src/host_collect/collector.py
+++ b/src/host_collect/collector.py
@@ -51,7 +51,7 @@ class HostCollector:
             self._visualize(cfg[:64])
 
             cfg_hex = cfg.hex()
-            msix_info = self._parse_msix(cfg)
+            msix_info = self._parse_msix(cfg_hex)
             
             # Extract device identifiers from config space
             device_ids = self._extract_device_ids(cfg)
@@ -134,9 +134,11 @@ class HostCollector:
             )
             return None
 
-    def _parse_msix(self, cfg: bytes) -> Dict[str, Any]:
+    def _parse_msix(self, cfg_hex: str) -> Dict[str, Any]:
+        # parse_msix_capability expects the config space as a hex string,
+        # not raw bytes (see issue #612).
         try:
-            info = parse_msix_capability(cfg)
+            info = parse_msix_capability(cfg_hex)
             if not info:
                 return {}
             # Normalize keys expected by MSI-X manager

--- a/tests/test_host_collector.py
+++ b/tests/test_host_collector.py
@@ -1,9 +1,5 @@
-import types
-import sys
-from pathlib import Path
 
 import json
-import pytest
 
 
 def test_host_collector_writes_datastore(tmp_path, monkeypatch):
@@ -49,3 +45,47 @@ def test_host_collector_writes_datastore(tmp_path, monkeypatch):
     assert "config_space_hex" in msix
     assert "msix_info" in msix
     assert isinstance(msix["msix_info"], dict)
+
+
+def _build_config_space_with_msix() -> bytes:
+    """Build a 256-byte config space exposing an MSI-X capability.
+
+    Models the donor in issue #612: MSI-X cap at 0xB0, table size 4,
+    table BIR 4 / offset 0, PBA BIR 4 / offset 0x800.
+    """
+    cfg = bytearray(256)
+    cfg[0:2] = (0x10EC).to_bytes(2, "little")  # vendor
+    cfg[2:4] = (0x8161).to_bytes(2, "little")  # device
+    cfg[0x06:0x08] = (0x0010).to_bytes(2, "little")  # status: capabilities bit
+    cfg[0x34] = 0xB0  # capabilities pointer
+    cfg[0xB0] = 0x11  # MSI-X capability ID
+    cfg[0xB1] = 0x00  # next pointer (end of list)
+    cfg[0xB2:0xB4] = (0x0003).to_bytes(2, "little")  # message control: size-1=3
+    cfg[0xB4:0xB8] = (0x00000004).to_bytes(4, "little")  # table BIR=4, offset=0
+    cfg[0xB8:0xBC] = (0x00000804).to_bytes(4, "little")  # PBA BIR=4, offset=0x800
+    return bytes(cfg)
+
+
+def test_host_collector_extracts_msix_info(tmp_path, monkeypatch):
+    """Regression for #612: MSI-X must be parsed, not written as zeros.
+
+    The collector previously passed raw bytes to parse_msix_capability(),
+    which expects a hex string, so MSI-X was silently reported as absent.
+    """
+    cfg_bytes = _build_config_space_with_msix()
+
+    from pcileechfwgenerator.host_collect.collector import HostCollector
+
+    monkeypatch.setattr(HostCollector, "_read_config_space", lambda self: cfg_bytes)
+
+    hc = HostCollector(bdf="0000:06:00.0", datastore=tmp_path, logger=None)
+    assert hc.run() == 0
+
+    msix = json.loads((tmp_path / "msix_data.json").read_text())
+    info = msix["msix_info"]
+
+    assert info["table_size"] == 4
+    assert info["table_bir"] == 4
+    assert info["table_offset"] == 0
+    assert info["pba_bir"] == 4
+    assert info["pba_offset"] == 0x800


### PR DESCRIPTION
## Summary

Fixes #612. `--host-collect-only` reported `[PCICAP] MSI-X capability not found` and wrote a zeroed `msix_info` structure even when the donor device clearly exposes MSI-X.

## Root cause

`HostCollector.run()` passed the **raw config-space bytes** to `parse_msix_capability()`:

```python
cfg_hex = cfg.hex()
msix_info = self._parse_msix(cfg)   # <- raw bytes
```

But `parse_msix_capability(cfg)` is documented and implemented to take a **hex string** — it calls `hex_to_bytes(cfg)` internally. When handed `bytes`, the capability walker silently returns `None`, so MSI-X is reported as absent and a zeroed struct is written.

This is exactly why the reporter's standalone reproduction worked (they passed `config_space_hex`, a hex string) while the collector path failed.

## Fix

- Pass `cfg_hex` to `_parse_msix()` instead of `cfg`.
- Update `_parse_msix()` signature to `cfg_hex: str` with a clarifying comment.

## Testing

Adds `test_host_collector_extracts_msix_info`, which builds a 256-byte config space with an MSI-X capability (modeled on the issue's Realtek RTL8111/8168 donor: cap at 0xB0, table size 4, table BIR 4, PBA offset 0x800) and asserts the collector serializes the correct values instead of zeros.

```
298 passed, 3 skipped  (msix/capability/template/host_collect subset)
```

The new test fails before the fix (`assert 0 == 4`) and passes after.