### PR TITLE
fix(template-discovery): discover .xdc constraints under src/ (#616)

### DIFF
--- a/src/file_management/template_discovery.py
+++ b/src/file_management/template_discovery.py
@@ -43,7 +43,7 @@ class TemplateDiscovery:
             "hdl/*.sv", "hdl/*.svh"
         ],
         "verilog": ["*.v", "src/*.v", "rtl/*.v", "hdl/*.v"],
-        "constraints": ["*.xdc", "constraints/*.xdc", "xdc/*.xdc"],
+        "constraints": ["*.xdc", "constraints/*.xdc", "xdc/*.xdc", "src/*.xdc"],
         "ip_config": ["*.xci", "ip/*.xci", "ips/*.xci"],
     }
 

--- a/tests/test_template_discovery_headers.py
+++ b/tests/test_template_discovery_headers.py
@@ -35,7 +35,13 @@ def mock_board_structure(tmp_path):
     (src_dir / "bar_layout_pkg.svh").write_text(
         "package bar_layout_pkg; endpackage"
     )
-    
+
+    # Create a constraints file stored under src/ (issue #616: the
+    # 75t484_x1 board keeps its .xdc here, not in the board root).
+    (src_dir / "pcileech_75t484_x1.xdc").write_text(
+        "# placeholder constraints"
+    )
+
     return {
         "repo_root": repo_root,
         "board_path": board_path,
@@ -92,6 +98,42 @@ def test_discover_templates_finds_header_files(mock_board_structure):
     
     # Verify total count (2 .sv + 3 .svh = 5)
     assert len(sv_files) == 5
+
+
+def test_template_patterns_include_src_xdc():
+    """Regression for #616: constraints must include src/*.xdc."""
+    patterns = TemplateDiscovery.TEMPLATE_PATTERNS
+
+    assert "constraints" in patterns
+    constraint_patterns = patterns["constraints"]
+
+    assert "*.xdc" in constraint_patterns
+    assert "constraints/*.xdc" in constraint_patterns
+    assert "xdc/*.xdc" in constraint_patterns
+    # The 75t484_x1 board keeps its .xdc under src/.
+    assert "src/*.xdc" in constraint_patterns
+
+
+def test_discover_templates_finds_src_constraints(mock_board_structure):
+    """Regression for #616: a constraint under src/ must be discovered."""
+    board_name = mock_board_structure["board_name"]
+    board_path = mock_board_structure["board_path"]
+    repo_root = mock_board_structure["repo_root"]
+
+    with mock.patch(
+        "pcileechfwgenerator.file_management.repo_manager.RepoManager.ensure_repo",
+        return_value=repo_root,
+    ), mock.patch(
+        "pcileechfwgenerator.file_management.repo_manager.RepoManager.get_board_path",
+        return_value=board_path,
+    ):
+        templates = TemplateDiscovery.discover_templates(
+            board_name, repo_root=repo_root
+        )
+
+    assert "constraints" in templates
+    xdc_filenames = [f.name for f in templates["constraints"]]
+    assert "pcileech_75t484_x1.xdc" in xdc_filenames
 
 
 def test_get_source_files_includes_headers(mock_board_structure):


### PR DESCRIPTION
## Summary

Fixes #616. `template_discovery.py` only looked for `.xdc` constraints in the board root, `constraints/`, and `xdc/` — but the `pcileech_75t484_x1` board stores its constraint file under `src/`. `board_discovery.py` already includes `src/` in its search, so the template validator used a narrower, inconsistent pattern set and missed the file.

## Fix

Add `src/*.xdc` to the `constraints` entry in `TEMPLATE_PATTERNS`, matching `board_discovery` behavior.

```diff
-        "constraints": ["*.xdc", "constraints/*.xdc", "xdc/*.xdc"],
+        "constraints": ["*.xdc", "constraints/*.xdc", "xdc/*.xdc", "src/*.xdc"],
```

## Testing

Adds two regression tests:
- `test_template_patterns_include_src_xdc` — asserts `src/*.xdc` is present in `TEMPLATE_PATTERNS["constraints"]`.
- `test_discover_templates_finds_src_constraints` — places an `.xdc` under `src/` in a mock board layout and asserts `discover_templates` surfaces it.

```
8 passed  (tests/test_template_discovery_headers.py)
```

Both new tests fail before the fix and pass after.