### PR TITLE
test(tui): force Textual headless driver so App tests run without tty (CI fix)

### DIFF
--- a/tests/tui/conftest.py
+++ b/tests/tui/conftest.py
@@ -35,5 +35,7 @@ _HEADLESS_DRIVER = "textual.drivers.headless_driver:HeadlessDriver"
 def _force_headless_textual_driver(monkeypatch):
     """Force Textual to use the headless driver (no ``tty`` import)."""
     monkeypatch.setenv("TEXTUAL_DRIVER", _HEADLESS_DRIVER)
-    monkeypatch.setattr(constants, "DRIVER", _HEADLESS_DRIVER, raising=False)
-    yield
+    # raising=True (the default) so the suite fails fast if Textual ever
+    # renames/removes ``constants.DRIVER`` rather than silently running
+    # against the real platform driver.
+    monkeypatch.setattr(constants, "DRIVER", _HEADLESS_DRIVER)

--- a/tests/tui/conftest.py
+++ b/tests/tui/conftest.py
@@ -1,0 +1,39 @@
+"""Shared fixtures for the Textual TUI test suite.
+
+Forces the Textual *headless* driver for every test in ``tests/tui``.
+
+Why this exists
+---------------
+Tests that instantiate a Textual ``App`` (e.g. via ``App.run_test()``) trigger
+``App.__init__`` -> ``App.get_driver_class()``. On a normal POSIX host that
+imports ``textual.drivers.linux_driver``, whose module body does ``import tty``.
+
+In the trimmed CI Python / hosted toolcache environment the ``tty`` stdlib
+module is not importable, so constructing *any* ``App`` raises
+``ModuleNotFoundError: No module named 'tty'`` before a headless driver can be
+selected.
+
+``App.get_driver_class()`` short-circuits on ``textual.constants.DRIVER``
+(populated from the ``TEXTUAL_DRIVER`` env var at import time): when it is set
+to a ``module:Class`` path it imports *that* driver and never touches the linux
+driver. Pointing it at ``HeadlessDriver`` makes these tests run genuinely
+headless in CI -- preserving their assertions -- without importing ``tty``.
+
+We set both the environment variable and ``constants.DRIVER`` directly because
+the constant is read once at module import; patching the attribute is what
+takes effect for the already-imported module, while the env var keeps any
+freshly-spawned/re-imported code in agreement.
+"""
+
+import pytest
+from textual import constants
+
+_HEADLESS_DRIVER = "textual.drivers.headless_driver:HeadlessDriver"
+
+
+@pytest.fixture(autouse=True)
+def _force_headless_textual_driver(monkeypatch):
+    """Force Textual to use the headless driver (no ``tty`` import)."""
+    monkeypatch.setenv("TEXTUAL_DRIVER", _HEADLESS_DRIVER)
+    monkeypatch.setattr(constants, "DRIVER", _HEADLESS_DRIVER, raising=False)
+    yield


### PR DESCRIPTION
## Root cause

The `Unit Tests (Python 3.11)` and `Unit Tests (Python 3.12)` CI jobs fail with:

```
ModuleNotFoundError: No module named 'tty'
  textual/app.py: in get_driver_class
      from textual.drivers.linux_driver import LinuxDriver
  textual/drivers/linux_driver.py:9: in <module>
      import tty
```

The 5 failing tests (added in #609) all build a Textual `App` and call `App.run_test()`. `App.__init__` calls `App.get_driver_class()`, which on POSIX imports `textual.drivers.linux_driver` — whose module body does `import tty`. In the trimmed CI Python / hosted toolcache environment `tty` is not importable, so construction of *any* `App` raises `ModuleNotFoundError` before a headless driver can be selected. Locally on macOS `tty` is importable, so the tests pass — which is why this only fails in CI.

Failing tests:
- `tests/tui/test_dialogs_base.py::test_confirmation_dialog_escape_returns_false`
- `tests/tui/test_dialogs_base.py::test_help_dialog_escape_returns_true`
- `tests/tui/test_dialogs_base.py::test_file_path_input_dialog_escape_returns_none`
- `tests/tui/test_virtual_device_table_cursor.py::test_cursor_stays_on_selected_device_after_viewport_shift`
- `tests/tui/test_virtual_device_table_cursor.py::test_cursor_clamps_to_zero_when_selection_scrolls_out`

## Fix

`App.get_driver_class()` short-circuits on `textual.constants.DRIVER` (populated from the `TEXTUAL_DRIVER` env var): when set to a `module:Class` path it imports *that* driver and never touches the linux driver.

Added `tests/tui/conftest.py` with an autouse fixture that points `constants.DRIVER` (and `TEXTUAL_DRIVER`) at `textual.drivers.headless_driver:HeadlessDriver`. This makes every `App` test in `tests/tui` run genuinely headless — no `tty` import — while preserving all existing assertions (no skips, no weakened coverage). Single-point fix scoped entirely to TUI test infrastructure.

`constants.DRIVER` is read once at import, so the fixture patches the already-imported attribute directly (what actually takes effect) and also sets the env var to keep any re-imported/spawned code in agreement.

## Verification

Simulated the CI condition by making `tty` unimportable (`sys.modules['tty']=None`, which makes `import tty` raise `ModuleNotFoundError`).

**Before fix** — `tty` unimportable:
```
tests/tui/test_dialogs_base.py:35: in _harness
    return _Harness(), captured
textual/app.py: in get_driver_class
    from textual.drivers.linux_driver import LinuxDriver
textual/drivers/linux_driver.py:9: in <module>
    import tty
E   ModuleNotFoundError: import of tty halted; None in sys.modules
============================== 1 failed in 0.57s ===============================
```

**After fix** — `tty` unimportable:
```
============================== 5 passed in 5.62s ===============================
```

Also verified, after the fix:
- 5 tests, normal local run: `5 passed`
- Full `tests/tui/` dir, normal: `83 passed`
- Full `tests/tui/` dir, `tty` unimportable: `83 passed`
