### PR TITLE
fix(donor): parse PCI IDs as hex + propagate subsystem IDs (#620, #621)

### DIFF
--- a/src/device_clone/pcileech_context.py
+++ b/src/device_clone/pcileech_context.py
@@ -1276,15 +1276,17 @@ class PCILeechContextBuilder:
         }
 
         if identifiers.subsystem_vendor_id:
+            _svid_int = int(identifiers.subsystem_vendor_id, 16)
             device_config_dict["subsystem_vendor_id_hex"] = safe_format(
-                "0x{value:04X}",
-                value=int(identifiers.subsystem_vendor_id, 16),
+                "0x{value:04X}", value=_svid_int
             )
+            device_config_dict["subsystem_vendor_id_int"] = _svid_int
         if identifiers.subsystem_device_id:
+            _sdid_int = int(identifiers.subsystem_device_id, 16)
             device_config_dict["subsystem_device_id_hex"] = safe_format(
-                "0x{value:04X}",
-                value=int(identifiers.subsystem_device_id, 16),
+                "0x{value:04X}", value=_sdid_int
             )
+            device_config_dict["subsystem_device_id_int"] = _sdid_int
 
         if hasattr(self.config, "device_config"):
             caps = getattr(self.config.device_config, "capabilities", None)

--- a/src/device_clone/pcileech_context.py
+++ b/src/device_clone/pcileech_context.py
@@ -1046,12 +1046,21 @@ class PCILeechContextBuilder:
         from pcileechfwgenerator.device_clone.constants import get_fallback_vendor_id
 
         def _parse_hex_id(val):
-            try:
-                if isinstance(val, str) and val.startswith("0x"):
-                    return int(val, 16)
-                return int(val) if val else None
-            except (ValueError, TypeError):
+            # PCI IDs are always hexadecimal. Parse bare strings as base-16
+            # (int(x, 16) also accepts a "0x" prefix); never as decimal. See #620.
+            if val is None or isinstance(val, bool):
                 return None
+            if isinstance(val, int):
+                return val
+            if isinstance(val, str):
+                s = val.strip()
+                if not s:
+                    return None
+                try:
+                    return int(s, 16)
+                except ValueError:
+                    return None
+            return None
 
         fallback_vendor_id = get_fallback_vendor_id(
             prefer_random=getattr(self.config, "test_mode", False)

--- a/src/device_clone/pcileech_generator.py
+++ b/src/device_clone/pcileech_generator.py
@@ -514,6 +514,12 @@ class PCILeechGenerator:
             "device_id": format(device_info.get("device_id", 0), "04x"),
             "class_code": format(device_info.get("class_code", 0), "06x"),
             "revision_id": format(device_info.get("revision_id", 0), "02x"),
+            "subsystem_vendor_id": format(
+                device_info.get("subsystem_vendor_id", 0), "04x"
+            ),
+            "subsystem_device_id": format(
+                device_info.get("subsystem_device_id", 0), "04x"
+            ),
             "bars": device_info.get("bars", []),
             "config_space_size": len(config_space_bytes),
         }

--- a/src/vivado_handling/fifo_donor_patcher.py
+++ b/src/vivado_handling/fifo_donor_patcher.py
@@ -230,6 +230,30 @@ def _coerce_int(value) -> Optional[int]:
     return None
 
 
+def _coerce_hex_id(value) -> Optional[int]:
+    """Coerce a PCI identifier to int, treating bare strings as hexadecimal.
+
+    PCI vendor/device/subsystem/revision IDs are *always* hexadecimal, so a
+    bare string like ``"1060"`` must parse as ``0x1060`` — never decimal 1060.
+    Unlike :func:`_coerce_int` (which tolerates decimal for mixed-semantics
+    fields such as max_payload_size), this never falls back to base-10.
+    See issues #620 / #621.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        s = value.strip()
+        if not s:
+            return None
+        try:
+            return int(s, 16)  # also accepts a "0x"/"0X" prefix
+        except ValueError:
+            return None
+    return None
+
+
 def donor_ids_from_template_context(
     template_context: dict,
 ) -> Optional[DonorIDs]:
@@ -252,7 +276,7 @@ def donor_ids_from_template_context(
         value = device_config.get(int_key)
         if value is None:
             value = device_config.get(str_key)
-        return _coerce_int(value)
+        return _coerce_hex_id(value)
 
     vendor_id = pick("vendor_id_int", "vendor_id")
     device_id = pick("device_id_int", "device_id")

--- a/tests/test_fifo_donor_patcher.py
+++ b/tests/test_fifo_donor_patcher.py
@@ -18,6 +18,7 @@ if str(project_root) not in sys.path:
 from pcileechfwgenerator.vivado_handling.fifo_donor_patcher import (
     DonorIDs,
     FifoPatchError,
+    _coerce_hex_id,
     apply_fifo_donor_patch,
     donor_ids_from_template_context,
     patch_pcileech_fifo,
@@ -583,3 +584,29 @@ class TestBuildWiring:
         }
         with pytest.raises(FifoPatchError):
             builder._patch_fifo_with_donor_ids(result)
+
+
+# ---------------------------------------------------------------------------
+# _coerce_hex_id: bare strings must be treated as hex (issues #620, #621)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("8086", 0x8086),   # bare all-digit hex must be hex, not decimal
+        ("0264", 0x0264),   # leading zero, all digits
+        ("1060", 0x1060),   # the #621 subsystem case
+        ("aaaa", 0xAAAA),   # bare hex with letters
+        ("10ec", 0x10EC),
+        ("0x8086", 0x8086),  # prefixed unchanged
+        ("0X1B21", 0x1B21),  # uppercase prefix
+        (0x8086, 0x8086),    # int passthrough
+        ("", None),
+        (None, None),
+        (True, None),        # bool rejected
+        ("zzzz", None),      # invalid
+    ],
+)
+def test_coerce_hex_id_parses_bare_strings_as_hex(value, expected):
+    assert _coerce_hex_id(value) == expected

--- a/tests/test_fifo_donor_patcher.py
+++ b/tests/test_fifo_donor_patcher.py
@@ -610,3 +610,19 @@ class TestBuildWiring:
 )
 def test_coerce_hex_id_parses_bare_strings_as_hex(value, expected):
     assert _coerce_hex_id(value) == expected
+
+
+def test_donor_ids_subsystem_bare_hex_resolves():
+    """A bare-hex subsystem_device_id like "1060" must resolve to 0x1060,
+    not decimal-misparsed 0x0424 (#621)."""
+    ctx = {
+        "device_config": {
+            "vendor_id": "1b21",
+            "device_id": "1060",
+            "subsystem_vendor_id": "1043",
+            "subsystem_device_id": "1060",  # bare, all-digit
+        }
+    }
+    donor = donor_ids_from_template_context(ctx)
+    assert donor is not None
+    assert donor.subsystem_id == 0x1060

--- a/tests/test_pcileech_context.py
+++ b/tests/test_pcileech_context.py
@@ -14,33 +14,21 @@ core device cloning logic and VFIO device interaction. Tests include:
 
 """
 
-import ctypes
-import fcntl
-import hashlib
-from logging import config
-import os
-import struct
 import sys
 from contextlib import contextmanager
-from dataclasses import asdict, dataclass, field
-from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
-from unittest.mock import MagicMock, Mock, PropertyMock, call, mock_open, patch
+from typing import Any, Dict, List, Optional
+from unittest.mock import Mock, patch
 
 import pytest
 
 from pcileechfwgenerator.cli.vfio_constants import (VFIO_DEVICE_GET_REGION_INFO,
-                                    VFIO_GROUP_GET_DEVICE_FD,
                                     VFIO_REGION_INFO_FLAG_MMAP,
                                     VFIO_REGION_INFO_FLAG_READ,
-                                    VFIO_REGION_INFO_FLAG_WRITE,
-                                    VfioRegionInfo)
+                                    VFIO_REGION_INFO_FLAG_WRITE)
 from pcileechfwgenerator.device_clone.behavior_profiler import (BehaviorProfile,
                                                 RegisterAccess, TimingPattern)
-from pcileechfwgenerator.device_clone.config_space_manager import BarInfo
 from pcileechfwgenerator.device_clone.fallback_manager import (FallbackManager,
                                                get_global_fallback_manager)
-from pcileechfwgenerator.device_clone.overlay_mapper import OverlayMapper
 from pcileechfwgenerator.device_clone.pcileech_context import (BarConfiguration, ContextError,
                                                DeviceIdentifiers,
                                                PCILeechContextBuilder,
@@ -1324,3 +1312,26 @@ class TestRegressions:
         # Should fall back to main IDs
         assert identifiers.subsystem_vendor_id == "10ee"
         assert identifiers.subsystem_device_id == "7024"
+
+
+def test_add_numeric_id_aliases_parses_bare_hex():
+    """Bare-hex vendor/device IDs must not fall back to Intel 0x8086 (#620)."""
+    import logging
+
+    from pcileechfwgenerator.device_clone import pcileech_context as ctx_mod
+
+    builder = ctx_mod.PCILeechContextBuilder.__new__(
+        ctx_mod.PCILeechContextBuilder
+    )
+
+    class _Cfg:
+        test_mode = False
+
+    builder.config = _Cfg()
+    builder.logger = logging.getLogger("test")
+
+    context = {"vendor_id": "aaaa", "device_id": "0264"}
+    builder._add_numeric_id_aliases(context)
+
+    assert context["vendor_id_int"] == 0xAAAA  # not Intel 0x8086 fallback
+    assert context["device_id_int"] == 0x0264  # not decimal 264

--- a/tests/test_pcileech_context.py
+++ b/tests/test_pcileech_context.py
@@ -1335,3 +1335,37 @@ def test_add_numeric_id_aliases_parses_bare_hex():
 
     assert context["vendor_id_int"] == 0xAAAA  # not Intel 0x8086 fallback
     assert context["device_id_int"] == 0x0264  # not decimal 264
+
+
+def test_build_device_config_writes_subsystem_int_aliases():
+    """_build_device_config must emit subsystem *_int keys so the donor-ID
+    reader never falls back to the ambiguous string path (#621)."""
+    import logging
+
+    from pcileechfwgenerator.device_clone import pcileech_context as ctx_mod
+
+    builder = ctx_mod.PCILeechContextBuilder.__new__(
+        ctx_mod.PCILeechContextBuilder
+    )
+
+    class _Cfg:
+        test_mode = False
+
+    builder.config = _Cfg()
+    builder.logger = logging.getLogger("test")
+    builder.device_bdf = "0000:03:00.0"
+
+    identifiers = ctx_mod.DeviceIdentifiers(
+        vendor_id="1b21",
+        device_id="1060",
+        class_code="010400",
+        revision_id="00",
+        subsystem_vendor_id="1043",
+        subsystem_device_id="8730",
+    )
+
+    dc = builder._build_device_config(
+        identifiers, behavior_profile=None, config_space_data={}
+    )
+    assert dc["subsystem_vendor_id_int"] == 0x1043
+    assert dc["subsystem_device_id_int"] == 0x8730

--- a/tests/test_pcileech_generator_fixes.py
+++ b/tests/test_pcileech_generator_fixes.py
@@ -12,8 +12,7 @@ This test suite covers the following fixes:
 """
 
 from pathlib import Path
-from typing import Any, Dict, Optional
-from unittest.mock import Mock, MagicMock, patch, call
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -543,6 +542,38 @@ def test_log_debug_safe_imported():
     
     assert log_debug_safe is not None
     assert callable(log_debug_safe)
+
+
+# --- Test config_space_data includes subsystem IDs (#621) -------------------
+
+
+def test_config_space_data_includes_subsystem_ids(generator, mock_config_space_manager):
+    """config_space_data must carry subsystem IDs so they don't collapse to
+    device_id downstream (#621)."""
+    device_info = {
+        "vendor_id": 0x1B21,
+        "device_id": 0x1060,
+        "class_code": 0x010601,
+        "revision_id": 0x03,
+        "subsystem_vendor_id": 0x1043,
+        "subsystem_device_id": 0x8730,
+        "bars": [],
+    }
+    # Configure the mock to return device_info with subsystem IDs
+    mock_config_space_manager.extract_device_info = Mock(return_value=device_info)
+
+    config_space_bytes = bytes(256)
+
+    with patch(
+        "pcileechfwgenerator.device_clone.pcileech_generator.lookup_device_info",
+        return_value=device_info,
+    ):
+        result = generator._process_config_space_bytes(config_space_bytes)
+
+    assert result["subsystem_vendor_id"] == "1043"
+    assert result["subsystem_device_id"] == "8730"
+    # The bug symptom: subsystem_device_id must NOT equal device_id.
+    assert result["subsystem_device_id"] != result["device_id"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes two linked bugs in the donor-ID pipeline (lineage of #593) where a donor device's real PCI IDs get corrupted before reaching the Vivado PCIe IP core, so the host enumerates the wrong device. Root cause: **PCI IDs are always hexadecimal, but the parsing helpers treated bare (non-`0x`-prefixed) strings as decimal.**

Closes #620. Closes #621.

## #620 — VID/DID become `0x8086` / garbage
`_parse_hex_id` (`pcileech_context.py`) and the shared `_coerce_int` (`fifo_donor_patcher.py`) only took the hex branch for `"0x"`-prefixed strings. But values reaching them are bare lowercase zero-padded hex (`"aaaa"`, `"0264"`) from `IdentifierNormalizer.normalize_hex`. Result:
- `"aaaa"` → `int("aaaa")` raises → `None` → falls back to **Intel `0x8086`**
- `"0264"` → `int("0264")` → decimal misparse

**Fix:** PCI IDs parse with `int(s, 16)` unconditionally (which still accepts a `0x` prefix).
- `_parse_hex_id` is now hex-only.
- A **new** hex-only `_coerce_hex_id` is used by `donor_ids_from_template_context`'s `pick()` for the PCI-ID fields. The shared `_coerce_int` is intentionally **left decimal-tolerant**, because `pcie_ip_donor_override.py` uses it for non-ID fields (`max_payload_size`, `link_width`, `class_code`) where decimal strings are legitimate — changing it broke `test_class_code_accepts_int_or_string`.

> Note vs. the issue's proposed fix: a plain "try hex, fall back to decimal" is still wrong for all-digit IDs like `"0264"` (valid as both bases). The fix commits to hex-only.

## #621 — `Subsystem_ID` equals `Device_ID`
Two independent omissions:
1. `config_space_data` (`pcileech_generator.py`) omitted `subsystem_vendor_id`/`subsystem_device_id`, so `normalize_subsystem(None, device_id)` fell back to `device_id`. **(dominant cause)**
2. `_build_device_config` wrote `subsystem_*_hex` but never `subsystem_*_int`, so `pick()` fell through to the bare-string path.

**Fix:** add both subsystem keys to `config_space_data`; emit `subsystem_*_int` aliases. (`"0000"` for a genuinely 0:0-subsystem device correctly falls back to the main vendor/device via the existing `normalize_subsystem` convention.)

## Tests
- `_coerce_hex_id` / `_parse_hex_id`: bare-hex cases (`"aaaa"`, `"0264"`, `"1060"`, `"8086"`) — each fails on the old logic.
- `config_space_data` carries subsystem IDs and `subsystem_device_id != device_id`.
- `subsystem_*_int` aliases written; end-to-end bare-hex subsystem resolves to `0x1060`.
- Full suite (excl. env-gated `tests/e2e`): **2558 passed, 40 skipped**.

## Notes
- Independent of #622 (no file overlap), but **#622 should land after this** — its XCI patcher consumes the donor produced here, which is only parsed correctly with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
