### PR TITLE
feat(vivado): patch XML-format XCI files with donor IDs (#622 follow-up)

### DIFF
--- a/docs/superpowers/specs/2026-05-29-xci-xml-donor-ids-design.md
+++ b/docs/superpowers/specs/2026-05-29-xci-xml-donor-ids-design.md
@@ -1,0 +1,170 @@
+# XML-format XCI donor-ID patching — Design
+
+**Date:** 2026-05-29
+**Status:** Approved (brainstorming complete)
+**Branch:** `fix/xci-xml-donor-ids` (off `main` @ `b9a5f22`)
+**Follows:** #622 / PR #624 (merged) — which added `patch_xci_donor_ids` for JSON-format XCIs only.
+
+---
+
+## Problem
+
+`patch_xci_donor_ids` (in `src/vivado_handling/ip_lock_resolver.py`) rewrites the staged `pcie_7x_0.xci` so Vivado's PCIe IP baseline matches the donor before the project opens. It only matches **JSON-format** XCIs. Of 259 XCIs in the submodule, **41 are XML (IP-XACT/spirit) format**, including the `pcie_7x_0.xci` for **3 boards: pciescreamer, acorn_ft2232h, NeTV2**. For those boards the function matches zero fields and (since #624) logs a warning but leaves Xilinx defaults (`10EE`/`0666`/`020000`) in place — the original #622 bug persists for those boards.
+
+## Goal
+
+1. Patch donor IDs into **XML-format** XCIs as well as JSON, closing the gap for the 3 affected boards.
+2. Return **richer per-file outcome info** so the caller knows exactly which files were patched, which were seen-but-unmatched, and which errored.
+3. In `build.py`, surface unmatched **PCIe-core** files prominently: **prompt to continue when interactive (TTY); warn and auto-continue when non-interactive (CI/container)**. The build always proceeds after acknowledgement — it never silently ships wrong IDs without a visible, prominent message.
+
+## Non-goals (YAGNI)
+
+- Full IP-XACT modeling or schema validation.
+- External libraries. Investigation found `ipyxact`/`ipCorePackager` target a newer IP-XACT revision than Vivado's 2009 dialect and model VLNV identity, not the `CONFIG.*`/`MODELPARAM` fields we patch; `hdlmake` only reads the module name. The repo declares **no** XML dependency today. We use only stdlib.
+- Changing the JSON path's matching behavior.
+- Re-serializing XCIs via a DOM (would churn namespaces/formatting and risk Vivado disliking the rewrite).
+
+---
+
+## Verified facts (from investigation)
+
+- XML XCIs use the **same field-name suffixes and value format** as JSON. Example lines (real files):
+  ```
+  <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Vendor_ID">10EE</spirit:configurableElementValue>
+  <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.ven_id">10EE</spirit:configurableElementValue>
+  <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.class_code">020000</spirit:configurableElementValue>
+  <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Class_Code_Base">02</spirit:configurableElementValue>
+  ```
+  User-config block uses `PARAM_VALUE.<LongName>`; generated block uses `MODELPARAM_VALUE.<short_name>`. NeTV2 has **15 patchable ID fields**.
+- The codebase does **zero** XML parsing today; all XCI ops are `read_text` / `re.subn` / `write_text`. No XML deps declared.
+- Existing interactive-prompt convention (`src/templating/tcl_builder.py:1116`): gate on `sys.stdin.isatty()`, then `input(...)`; raise/abort if not a TTY.
+- **Only one production caller** of `patch_xci_donor_ids`: `build.py` (`_patch_fifo_with_donor_ids`, reads the `int` at lines 1958/1967/1973). Plus 3 tests in `tests/test_ip_lock_resolver.py`. All updated here.
+
+---
+
+## Design
+
+### Component 1 — `patch_xci_donor_ids` in `ip_lock_resolver.py`
+
+**New return type.** Replace the bare `int` with a small dataclass:
+
+```python
+@dataclass
+class XciPatchSummary:
+    patched: List[str]      # filenames actually rewritten
+    unmatched: List[str]    # XCIs seen but zero ID fields matched (the gap)
+    failed: List[str]       # filenames that errored (read/parse/write)
+    total_files: int        # total *.xci files discovered
+
+    @property
+    def num_patched(self) -> int:
+        return len(self.patched)
+
+    def has_unmatched_core(self) -> bool:
+        """True if any unmatched/failed file looks like the PCIe core."""
+        return any(
+            _is_pcie_core_xci(name)
+            for name in (*self.unmatched, *self.failed)
+        )
+```
+
+`_is_pcie_core_xci(name)` → `name.lower().startswith("pcie_7x")` (module-level helper; the PCIe core files in every board are named `pcie_7x_0.xci`).
+
+**Per-file algorithm** (replaces the current single-regex loop):
+
+1. Read text. On read error → append to `failed`, continue.
+2. **Sniff** first non-whitespace char: `{` → JSON; `<` → XML; otherwise → unknown.
+3. **If XML, validate** well-formedness with `xml.etree.ElementTree.fromstring(text)` inside a try. On `ET.ParseError`/any exception → append to `failed` (malformed), continue. (Validation only; we do NOT use the parsed tree to edit.)
+4. Pick the regex template for the detected format and run the substitution loop over the **same** `subs` list already built (vid/did/svid/sid + optional class-code split). Count `total` matches.
+   - JSON (unchanged): `("{key}"\s*:\s*\[\s*\{{\s*"value"\s*:\s*)"[0-9A-Fa-f]+"` → `\1"{val}"`
+   - XML (new): `(referenceId="(?:PARAM_VALUE|MODELPARAM_VALUE)\.{key}"\s*>)[0-9A-Fa-f]+(?=</)` → `\1{val}`
+     - Anchored on the exact `referenceId="…\.<key>"` so `class_code` can't match inside `Class_Code_Base`, and `ven_id` can't match inside `subsys_ven_id` (same key-anchoring discipline as the JSON path). Replaces only the element text between `>` and `</`.
+   - Unknown format (neither `{` nor `<`): skip substitution, `total = 0`.
+5. If `total > 0` and text changed → write, append to `patched`, log info.
+   Elif `total == 0` → append to `unmatched`, log the existing warning (refined to mention both JSON and XML were attempted).
+6. Wrap the whole per-file body in try/except → `failed` on any unexpected error (preserves today's never-crash behavior).
+
+Return `XciPatchSummary(...)`.
+
+**Helper for the two regexes.** Factor the substitution loop into a small internal helper that takes `(text, subs, fmt) -> (new_text, total)` to keep the per-file loop readable and each format's pattern isolated/testable. Keep it module-private.
+
+**Security note.** `ET.fromstring` on hostile XML is theoretically exposed to entity-expansion ("billion laughs"). These are trusted submodule files, not user input, so risk is negligible; the parse is wrapped so any exception is treated as "unverified format → `failed`" rather than crashing. (No new dependency; stdlib `xml.etree.ElementTree`.)
+
+### Component 2 — `build.py` `_patch_fifo_with_donor_ids`
+
+Replace the `n_xci = patch_xci_donor_ids(...)` / `if n_xci:` block (lines ~1958-1976) with handling for the new summary:
+
+```python
+summary = patch_xci_donor_ids(self.config.output_dir, donor, class_code=..., logger=..., prefix="BUILD")
+if summary.num_patched:
+    log_info_safe(... "Patched donor IDs into {count} XCI baseline file(s)" ...)
+
+if summary.has_unmatched_core():
+    self._handle_unpatched_pcie_core(summary, donor)   # new helper
+elif summary.unmatched:
+    log_warning_safe(... "Some non-core XCI files were left unpatched: {files}" ...)
+```
+
+New helper `_handle_unpatched_pcie_core(self, summary, donor)`:
+- Build a prominent multi-line WARNING block: which `pcie_7x*` file(s) were unpatched, the donor IDs that would otherwise be wrong (`vendor=0x.. device=0x..`), and remediation ("file uses an unrecognized XCI format; donor IDs may not reach the bitstream").
+- `if sys.stdin.isatty():` print the block, then `resp = input("Continue the build anyway? [y/N]: ")`. If `resp.strip().lower() not in ("y", "yes")` → raise to abort the build with a clear message.
+- `else:` (non-TTY) → log the prominent warning via `log_warning_safe` and continue.
+- Wrap the prompt in try/except so a prompt failure (e.g. `EOFError`) degrades to warn-and-continue, never an unhandled crash.
+
+The XCI patch continues to run regardless of the PCIe-IP TCL-override outcome (preserved from #624: `extra_ip_cfg` initialized to `None`, override `except` falls through).
+
+---
+
+## Data flow
+
+```
+build._patch_fifo_with_donor_ids
+  └─ patch_xci_donor_ids(output_dir/ip, donor, class_code)
+       └─ for each *.xci:  sniff format → (XML? validate via ET) → regex subn → classify
+       └─ returns XciPatchSummary(patched, unmatched, failed, total_files)
+  └─ if summary.num_patched: log
+  └─ if summary.has_unmatched_core():  _handle_unpatched_pcie_core
+        TTY  → prompt [y/N]; "n" aborts build
+        !TTY → prominent warning, continue
+```
+
+---
+
+## File structure
+
+| File | Change |
+|------|--------|
+| `src/vivado_handling/ip_lock_resolver.py` | Add `XciPatchSummary` dataclass, `_is_pcie_core_xci`, format-sniff + ET validation + XML regex; change `patch_xci_donor_ids` return type; private substitution helper. |
+| `src/build.py` | Update `_patch_fifo_with_donor_ids` to consume the summary; add `_handle_unpatched_pcie_core` (TTY-prompt / non-TTY-warn). |
+| `tests/test_ip_lock_resolver.py` | Update 3 existing tests for the new return type; add XML happy-path, XML `class_code=None`, malformed-XML→`failed`, real-fixture (NeTV2/pciescreamer) tests. |
+| `tests/` (build) | Add tests for `_handle_unpatched_pcie_core`: non-TTY continues; TTY + "n" aborts; TTY + "y" continues. |
+
+---
+
+## Testing
+
+**`patch_xci_donor_ids` (importlib pattern, per existing file):**
+- JSON happy-path still works and returns `XciPatchSummary` with the file in `patched` (regression for the #624 behavior).
+- XML happy-path: synthetic spirit-XML fixture with all ID fields → all patched, no `10EE`/`0666`/`020000` remain; file in `patched`.
+- XML `class_code=None`: class-code fields untouched, ID fields patched.
+- XML regex safety: `class_code` not matched inside `Class_Code_Base`; `ven_id` not inside `subsys_ven_id`.
+- Malformed XML (`<not-closed`): lands in `failed`, no crash, no write.
+- Unknown format (neither `{`/`<`): lands in `unmatched`.
+- **Real fixture:** copy an actual `NeTV2` (or `pciescreamer`) `pcie_7x_0.xci` into a tmp `ip/` dir, run, assert all 15 fields patched and no Xilinx defaults remain — the highest-value test.
+
+**`build._handle_unpatched_pcie_core`:**
+- Non-TTY (monkeypatch `sys.stdin.isatty`→False): logs warning, returns normally (build continues).
+- TTY + `input`→"n" (monkeypatch both): raises/aborts.
+- TTY + `input`→"y": continues.
+- `input` raises `EOFError`: degrades to continue (no crash).
+
+**Full suite:** `tests/ --ignore=tests/e2e` stays green (baseline 2559 passed / 40 skipped + new tests).
+
+---
+
+## Risks & mitigations
+
+- **Return-type break for callers:** only `build.py` consumes it; updated here. Grep confirmed no other production callers. Mitigation: change is deliberate and covered by tests.
+- **Regex on XML fragility:** mitigated by (a) ET well-formedness validation before trusting the XML path, (b) exact `referenceId` anchoring, (c) real-fixture test. Same justification as the already-reviewed JSON regex on stable, machine-generated files.
+- **Interactive prompt hanging CI:** mitigated by the `isatty()` gate (non-TTY never prompts) and EOFError fallback.
+- **XML reserialization churn:** avoided entirely — ET is used only to validate; edits remain regex text substitutions.

--- a/src/build.py
+++ b/src/build.py
@@ -1955,7 +1955,7 @@ class FirmwareBuilder:
                 patch_xci_donor_ids,
             )
 
-            n_xci = patch_xci_donor_ids(
+            xci_summary = patch_xci_donor_ids(
                 self.config.output_dir,
                 donor,
                 class_code=(
@@ -1964,13 +1964,13 @@ class FirmwareBuilder:
                 logger=self.logger,
                 prefix="BUILD",
             )
-            if n_xci:
+            if xci_summary.num_patched:
                 log_info_safe(
                     self.logger,
                     safe_format(
                         "  • Patched donor IDs into {count} XCI baseline "
                         "file(s)",
-                        count=n_xci,
+                        count=xci_summary.num_patched,
                     ),
                     prefix="BUILD",
                 )

--- a/src/vivado_handling/ip_lock_resolver.py
+++ b/src/vivado_handling/ip_lock_resolver.py
@@ -46,6 +46,35 @@ class XciPatchSummary:
         )
 
 
+def _apply_xci_subs(text: str, subs, fmt: str):
+    """Return (new_text, total_substitutions) for the given format.
+
+    ``fmt`` is "json" or "xml". JSON anchors on ``"key": [ { "value": ...``;
+    XML anchors on ``referenceId="(PARAM_VALUE|MODELPARAM_VALUE).key">VALUE<``.
+    Both anchor on the exact key so e.g. ``class_code`` cannot match inside
+    ``Class_Code_Base``.
+    """
+    import re as _re
+
+    new_text = text
+    total = 0
+    for key, val in subs:
+        if fmt == "json":
+            pattern = (
+                rf'("{key}"\s*:\s*\[\s*\{{\s*"value"\s*:\s*)"[0-9A-Fa-f]+"'
+            )
+            repl = rf'\1"{val}"'
+        else:  # xml
+            pattern = (
+                rf'(referenceId="(?:PARAM_VALUE|MODELPARAM_VALUE)\.{key}"\s*>)'
+                rf"[0-9A-Fa-f]+(?=</)"
+            )
+            repl = rf"\g<1>{val}"
+        new_text, n = _re.subn(pattern, repl, new_text)
+        total += n
+    return new_text, total
+
+
 def _discover_ip_dirs(root: Path) -> List[Path]:
     """Return every `ip` directory rooted at *root*."""
     ip_dirs: List[Path] = []
@@ -229,7 +258,7 @@ def patch_xci_donor_ids(
     class_code: Optional[int] = None,
     logger=None,
     prefix: str = "VIVADO",
-) -> int:
+) -> "XciPatchSummary":
     """Rewrite staged XCI files so their PCIe IDs match the donor.
 
     The upstream XCI ships with Xilinx defaults (Vendor_ID=10EE,
@@ -244,10 +273,8 @@ def patch_xci_donor_ids(
     ``donor`` must expose ``vendor_id``/``device_id``/``subsystem_vendor_id``/
     ``subsystem_id`` as ints (the ``DonorIDs`` dataclass). ``class_code`` is
     the 24-bit packed value (base<<16 | sub<<8 | interface); pass ``None`` to
-    leave class-code fields unchanged. Returns the number of files patched.
+    leave class-code fields unchanged. Returns an :class:`XciPatchSummary`.
     """
-    import re as _re
-
     logger = logger or get_logger(__name__)
 
     vid = f"{donor.vendor_id:04X}"
@@ -284,25 +311,49 @@ def patch_xci_donor_ids(
         ]
 
     ip_dirs = _discover_ip_dirs(ip_root)
-    patched = 0
+    summary = XciPatchSummary()
     for ip_dir in ip_dirs:
         for xci_file in ip_dir.glob("*.xci"):
+            summary.total_files += 1
             try:
                 text = xci_file.read_text(encoding="utf-8")
-                new_text = text
-                total = 0
-                for key, val in subs:
-                    # Anchor only through the "value" token; trailing keys
-                    # (resolve_type/usage/value_src) and whitespace vary.
-                    new_text, n = _re.subn(
-                        rf'("{key}"\s*:\s*\[\s*\{{\s*"value"\s*:\s*)"[0-9A-Fa-f]+"',
-                        rf'\1"{val}"',
-                        new_text,
-                    )
-                    total += n
+                stripped = text.lstrip()
+                if stripped.startswith("{"):
+                    fmt = "json"
+                elif stripped.startswith("<"):
+                    fmt = "xml"
+                else:
+                    fmt = "unknown"
+
+                if fmt == "xml":
+                    # Validate well-formedness before trusting the regex path.
+                    # Parse only — the edit stays a text substitution to avoid
+                    # namespace/formatting churn on reserialize.
+                    import xml.etree.ElementTree as _ET
+
+                    try:
+                        _ET.fromstring(text)
+                    except Exception:
+                        summary.failed.append(xci_file.name)
+                        log_warning_safe(
+                            logger,
+                            safe_format(
+                                "XCI {path} looks like XML but is not "
+                                "well-formed; left unpatched (issue #622).",
+                                path=xci_file.name,
+                            ),
+                            prefix=prefix,
+                        )
+                        continue
+
+                if fmt == "unknown":
+                    new_text, total = text, 0
+                else:
+                    new_text, total = _apply_xci_subs(text, subs, fmt)
+
                 if total > 0 and new_text != text:
                     xci_file.write_text(new_text, encoding="utf-8")
-                    patched += 1
+                    summary.patched.append(xci_file.name)
                     log_info_safe(
                         logger,
                         safe_format(
@@ -312,18 +363,20 @@ def patch_xci_donor_ids(
                         ),
                         prefix=prefix,
                     )
-                elif total == 0:
+                else:
+                    summary.unmatched.append(xci_file.name)
                     log_warning_safe(
                         logger,
                         safe_format(
-                            "No donor-ID fields matched in {path}; the file may "
-                            "use an unsupported (non-JSON) XCI format and was "
-                            "left unpatched (issue #622).",
+                            "No donor-ID fields matched in {path} "
+                            "(tried JSON and XML forms); left unpatched "
+                            "(issue #622).",
                             path=xci_file.name,
                         ),
                         prefix=prefix,
                     )
             except Exception as exc:
+                summary.failed.append(xci_file.name)
                 log_warning_safe(
                     logger,
                     safe_format(
@@ -334,16 +387,16 @@ def patch_xci_donor_ids(
                     prefix=prefix,
                 )
 
-    if patched:
+    if summary.num_patched:
         log_info_safe(
             logger,
             safe_format(
                 "Patched donor IDs in {count} XCI file(s)",
-                count=patched,
+                count=summary.num_patched,
             ),
             prefix=prefix,
         )
-    return patched
+    return summary
 
 
 def repair_ip_artifacts(

--- a/src/vivado_handling/ip_lock_resolver.py
+++ b/src/vivado_handling/ip_lock_resolver.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from pathlib import Path
 from stat import S_IWGRP, S_IWOTH, S_IWUSR
 from typing import Dict, List, Optional
@@ -17,6 +18,32 @@ from pcileechfwgenerator.string_utils import (
 
 LOCK_SUFFIXES = (".lck", ".lock")
 IP_FILE_SUFFIXES = (".xci", ".xcix")
+
+
+def _is_pcie_core_xci(name: str) -> bool:
+    """True if an XCI filename is the PCIe core whose stale IDs cause #622."""
+    return name.lower().startswith("pcie_7x")
+
+
+@dataclass
+class XciPatchSummary:
+    """Outcome of :func:`patch_xci_donor_ids` across all discovered XCIs."""
+
+    patched: List[str] = field(default_factory=list)
+    unmatched: List[str] = field(default_factory=list)
+    failed: List[str] = field(default_factory=list)
+    total_files: int = 0
+
+    @property
+    def num_patched(self) -> int:
+        return len(self.patched)
+
+    def has_unmatched_core(self) -> bool:
+        """True if any unmatched OR failed file is the PCIe core."""
+        return any(
+            _is_pcie_core_xci(name)
+            for name in (*self.unmatched, *self.failed)
+        )
 
 
 def _discover_ip_dirs(root: Path) -> List[Path]:

--- a/src/vivado_handling/ip_lock_resolver.py
+++ b/src/vivado_handling/ip_lock_resolver.py
@@ -351,18 +351,34 @@ def patch_xci_donor_ids(
                 else:
                     new_text, total = _apply_xci_subs(text, subs, fmt)
 
-                if total > 0 and new_text != text:
-                    xci_file.write_text(new_text, encoding="utf-8")
+                if total > 0:
+                    # Fields matched the donor-ID anchors. If the text changed
+                    # we rewrote it; if not, the baseline already holds the
+                    # donor values (idempotent re-run). Both count as patched
+                    # — only a zero-match file is genuinely unmatched.
+                    if new_text != text:
+                        xci_file.write_text(new_text, encoding="utf-8")
+                        log_info_safe(
+                            logger,
+                            safe_format(
+                                "Patched donor IDs ({n} field(s)) in {path}",
+                                n=total,
+                                path=xci_file.name,
+                            ),
+                            prefix=prefix,
+                        )
+                    else:
+                        log_info_safe(
+                            logger,
+                            safe_format(
+                                "Donor IDs already current ({n} field(s)) "
+                                "in {path}",
+                                n=total,
+                                path=xci_file.name,
+                            ),
+                            prefix=prefix,
+                        )
                     summary.patched.append(xci_file.name)
-                    log_info_safe(
-                        logger,
-                        safe_format(
-                            "Patched donor IDs ({n} field(s)) in {path}",
-                            n=total,
-                            path=xci_file.name,
-                        ),
-                        prefix=prefix,
-                    )
                 else:
                     summary.unmatched.append(xci_file.name)
                     log_warning_safe(

--- a/tests/test_ip_lock_resolver.py
+++ b/tests/test_ip_lock_resolver.py
@@ -4,9 +4,12 @@
 from __future__ import annotations
 
 import importlib.util
+import shutil
 import stat
 import sys
 from pathlib import Path
+
+import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_DIR = PROJECT_ROOT / "src"
@@ -356,3 +359,55 @@ def test_xci_patch_summary_helpers():
         patched=[], unmatched=[], failed=["PCIE_7X_0.xci"], total_files=1
     )
     assert s3.has_unmatched_core() is True  # case-insensitive, checks failed too
+
+
+def test_patch_xci_donor_ids_real_xml_fixture(tmp_path):
+    """Patch a real XML-format board XCI from the submodule (#622)."""
+    real_xci = (
+        PROJECT_ROOT
+        / "lib"
+        / "voltcyclone-fpga"
+        / "NeTV2"
+        / "ip"
+        / "pcie_7x_0.xci"
+    )
+    if not real_xci.exists():
+        pytest.skip("voltcyclone-fpga submodule not checked out")
+
+    patch_xci_donor_ids = ip_lock_resolver.patch_xci_donor_ids
+    ip_dir = tmp_path / "ip"
+    ip_dir.mkdir()
+    staged = ip_dir / "pcie_7x_0.xci"
+    shutil.copy(real_xci, staged)
+
+    class _Donor:
+        vendor_id = 0x1B21
+        device_id = 0x1060
+        subsystem_vendor_id = 0x1043
+        subsystem_id = 0x8730
+
+    summary = patch_xci_donor_ids(tmp_path, _Donor(), class_code=0x010601)
+    assert summary.num_patched == 1
+
+    text = staged.read_text(encoding="utf-8")
+    # No Xilinx defaults remain in any ID element text.
+    for ref in (
+        "PARAM_VALUE.Vendor_ID",
+        "PARAM_VALUE.Device_ID",
+        "PARAM_VALUE.Subsystem_Vendor_ID",
+        "PARAM_VALUE.Subsystem_ID",
+        "MODELPARAM_VALUE.ven_id",
+        "MODELPARAM_VALUE.dev_id",
+        "MODELPARAM_VALUE.subsys_ven_id",
+        "MODELPARAM_VALUE.subsys_id",
+    ):
+        assert f'{ref}">10EE<' not in text
+        assert f'{ref}">0666<' not in text
+        assert f'{ref}">0007<' not in text
+    assert 'MODELPARAM_VALUE.ven_id">1B21<' in text
+    assert 'MODELPARAM_VALUE.dev_id">1060<' in text
+    assert 'MODELPARAM_VALUE.class_code">010601<' in text
+    # Still valid XML after the edit.
+    import xml.etree.ElementTree as ET
+
+    ET.fromstring(text)  # raises if we corrupted it

--- a/tests/test_ip_lock_resolver.py
+++ b/tests/test_ip_lock_resolver.py
@@ -5,17 +5,22 @@ from __future__ import annotations
 
 import importlib.util
 import stat
+import sys
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_DIR = PROJECT_ROOT / "src"
 MODULE_PATH = SRC_DIR / "vivado_handling" / "ip_lock_resolver.py"
 
+_MODULE_NAME = "vivado_handling.ip_lock_resolver"
 spec = importlib.util.spec_from_file_location(
-    "vivado_handling.ip_lock_resolver",
+    _MODULE_NAME,
     MODULE_PATH,
 )
 ip_lock_resolver = importlib.util.module_from_spec(spec)
+# Register in sys.modules before exec_module so that dataclasses (Python 3.13+)
+# can resolve the module dict when processing @dataclass fields.
+sys.modules.setdefault(_MODULE_NAME, ip_lock_resolver)
 assert spec and spec.loader  # pragma: no cover - importlib contract
 spec.loader.exec_module(ip_lock_resolver)
 
@@ -229,3 +234,25 @@ def test_patch_xci_donor_ids_warns_on_unmatched_format(tmp_path):
 
     assert result == 0
     assert xci.read_text(encoding="utf-8") == xml_content
+
+
+def test_xci_patch_summary_helpers():
+    XciPatchSummary = ip_lock_resolver.XciPatchSummary
+    s = XciPatchSummary(
+        patched=["pcie_7x_0.xci"],
+        unmatched=["other.xci"],
+        failed=[],
+        total_files=2,
+    )
+    assert s.num_patched == 1
+    assert s.has_unmatched_core() is False
+
+    s2 = XciPatchSummary(
+        patched=[], unmatched=["pcie_7x_0.xci"], failed=[], total_files=1
+    )
+    assert s2.has_unmatched_core() is True
+
+    s3 = XciPatchSummary(
+        patched=[], unmatched=[], failed=["PCIE_7X_0.xci"], total_files=1
+    )
+    assert s3.has_unmatched_core() is True  # case-insensitive, checks failed too

--- a/tests/test_ip_lock_resolver.py
+++ b/tests/test_ip_lock_resolver.py
@@ -208,6 +208,33 @@ def test_patch_xci_donor_ids_skips_class_code_when_none(tmp_path):
     assert '"Class_Code_Base": [ { "value": "02"' in text  # untouched
 
 
+def test_patch_xci_donor_ids_already_patched_no_warning(tmp_path):
+    """An XCI that already holds the donor values must classify as patched,
+    not unmatched: fields match the anchors (total > 0) but no rewrite is
+    needed. It must not emit a false 'no fields matched' warning."""
+    patch_xci_donor_ids = ip_lock_resolver.patch_xci_donor_ids
+    ip_dir = tmp_path / "ip"
+    ip_dir.mkdir()
+    xci = ip_dir / "pcie_7x_0.xci"
+    # Values already equal the donor below.
+    xci.write_text(
+        '{ "Vendor_ID": [ { "value": "1B21", "resolve_type": "user" } ],'
+        '  "Device_ID": [ { "value": "1060", "resolve_type": "user" } ] }',
+        encoding="utf-8",
+    )
+
+    class _Donor:
+        vendor_id = 0x1B21
+        device_id = 0x1060
+        subsystem_vendor_id = 0x1043
+        subsystem_id = 0x8730
+
+    summary = patch_xci_donor_ids(tmp_path, _Donor(), class_code=None)
+    assert summary.num_patched == 1
+    assert summary.unmatched == []
+    assert summary.failed == []
+
+
 def test_patch_xci_donor_ids_warns_on_unmatched_format(tmp_path):
     """Returns 0 and leaves the file unchanged when no JSON fields match.
 

--- a/tests/test_ip_lock_resolver.py
+++ b/tests/test_ip_lock_resolver.py
@@ -160,8 +160,10 @@ def test_patch_xci_donor_ids(tmp_path):
         subsystem_vendor_id = 0x1043
         subsystem_id = 0x8730
 
-    patched = patch_xci_donor_ids(tmp_path, _Donor(), class_code=0x010601)
-    assert patched == 1
+    summary = patch_xci_donor_ids(tmp_path, _Donor(), class_code=0x010601)
+    assert summary.num_patched == 1
+    assert summary.patched == ["pcie_7x_0.xci"]
+    assert summary.unmatched == [] and summary.failed == []
 
     text = xci.read_text(encoding="utf-8")
     assert '"Vendor_ID": [ { "value": "1B21"' in text
@@ -196,7 +198,8 @@ def test_patch_xci_donor_ids_skips_class_code_when_none(tmp_path):
         subsystem_vendor_id = 0x1043
         subsystem_id = 0x8730
 
-    patch_xci_donor_ids(tmp_path, _Donor(), class_code=None)
+    summary = patch_xci_donor_ids(tmp_path, _Donor(), class_code=None)
+    assert summary.num_patched == 1
     text = xci.read_text(encoding="utf-8")
     assert '"Vendor_ID": [ { "value": "1B21"' in text
     assert '"Class_Code_Base": [ { "value": "02"' in text  # untouched
@@ -217,7 +220,7 @@ def test_patch_xci_donor_ids_warns_on_unmatched_format(tmp_path):
     # XML-style content — no JSON "key": [ { "value": ... } ] fields.
     xml_content = (
         '<?xml version="1.0" encoding="UTF-8"?>\n'
-        '<spirit:configurableElementValues>\n'
+        '<spirit:configurableElementValues xmlns:spirit="http://www.spiritconsortium.org/XMLSchema/SPIRIT/1685-2009">\n'
         '  <spirit:configurableElementValue '
         'spirit:referenceId="VENDOR_ID">10EE</spirit:configurableElementValue>\n'
         '</spirit:configurableElementValues>\n'
@@ -230,10 +233,107 @@ def test_patch_xci_donor_ids_warns_on_unmatched_format(tmp_path):
         subsystem_vendor_id = 0x1043
         subsystem_id = 0x8730
 
-    result = patch_xci_donor_ids(tmp_path, _Donor(), class_code=0x010601)
+    summary = patch_xci_donor_ids(tmp_path, _Donor(), class_code=0x010601)
 
-    assert result == 0
+    assert summary.num_patched == 0
+    assert "pcie_7x_0.xci" in summary.unmatched
     assert xci.read_text(encoding="utf-8") == xml_content
+
+
+def test_patch_xci_donor_ids_xml(tmp_path):
+    patch_xci_donor_ids = ip_lock_resolver.patch_xci_donor_ids
+
+    ip_dir = tmp_path / "ip"
+    ip_dir.mkdir()
+    xci = ip_dir / "pcie_7x_0.xci"
+    xci.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<spirit:design xmlns:spirit="http://www.spiritconsortium.org/x">\n'
+        '  <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.class_code">020000</spirit:configurableElementValue>\n'
+        '  <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.dev_id">0666</spirit:configurableElementValue>\n'
+        '  <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.subsys_id">0007</spirit:configurableElementValue>\n'
+        '  <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.subsys_ven_id">10EE</spirit:configurableElementValue>\n'
+        '  <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.ven_id">10EE</spirit:configurableElementValue>\n'
+        '  <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Class_Code_Base">02</spirit:configurableElementValue>\n'
+        '  <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Class_Code_Interface">00</spirit:configurableElementValue>\n'
+        '  <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Class_Code_Sub">00</spirit:configurableElementValue>\n'
+        '  <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Device_ID">0666</spirit:configurableElementValue>\n'
+        '  <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Subsystem_ID">0007</spirit:configurableElementValue>\n'
+        '  <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Subsystem_Vendor_ID">10EE</spirit:configurableElementValue>\n'
+        '  <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Vendor_ID">10EE</spirit:configurableElementValue>\n'
+        '</spirit:design>\n',
+        encoding="utf-8",
+    )
+
+    class _Donor:
+        vendor_id = 0x1B21
+        device_id = 0x1060
+        subsystem_vendor_id = 0x1043
+        subsystem_id = 0x8730
+
+    summary = patch_xci_donor_ids(tmp_path, _Donor(), class_code=0x010601)
+    assert summary.num_patched == 1
+
+    text = xci.read_text(encoding="utf-8")
+    assert ">1B21<" in text and ">1060<" in text
+    assert ">1043<" in text and ">8730<" in text
+    assert 'PARAM_VALUE.Class_Code_Base">01<' in text
+    assert 'PARAM_VALUE.Class_Code_Sub">06<' in text
+    assert 'PARAM_VALUE.Class_Code_Interface">01<' in text
+    assert 'MODELPARAM_VALUE.class_code">010601<' in text
+    assert ">10EE<" not in text and ">0666<" not in text and ">020000<" not in text
+    assert text.startswith('<?xml version="1.0"')
+    assert "xmlns:spirit" in text
+
+
+def test_patch_xci_donor_ids_xml_regex_safety(tmp_path):
+    """class_code must not match inside Class_Code_Base; ven_id not inside
+    subsys_ven_id (key-anchored, XML form)."""
+    patch_xci_donor_ids = ip_lock_resolver.patch_xci_donor_ids
+    ip_dir = tmp_path / "ip"
+    ip_dir.mkdir()
+    xci = ip_dir / "pcie_7x_0.xci"
+    xci.write_text(
+        '<?xml version="1.0"?>\n<r xmlns:spirit="x">\n'
+        '  <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.Class_Code_Base">02</spirit:configurableElementValue>\n'
+        '  <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.subsys_ven_id">10EE</spirit:configurableElementValue>\n'
+        '  <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.ven_id">10EE</spirit:configurableElementValue>\n'
+        '</r>\n',
+        encoding="utf-8",
+    )
+
+    class _Donor:
+        vendor_id = 0x1B21
+        device_id = 0x1060
+        subsystem_vendor_id = 0x1043
+        subsystem_id = 0x8730
+
+    patch_xci_donor_ids(tmp_path, _Donor(), class_code=0x010601)
+    text = xci.read_text(encoding="utf-8")
+    assert 'PARAM_VALUE.Class_Code_Base">01<' in text
+    assert 'MODELPARAM_VALUE.subsys_ven_id">1043<' in text
+    assert 'MODELPARAM_VALUE.ven_id">1B21<' in text
+
+
+def test_patch_xci_donor_ids_malformed_xml(tmp_path):
+    """Malformed XML lands in `failed`, not crash, not write."""
+    patch_xci_donor_ids = ip_lock_resolver.patch_xci_donor_ids
+    ip_dir = tmp_path / "ip"
+    ip_dir.mkdir()
+    xci = ip_dir / "pcie_7x_0.xci"
+    original = '<not-closed referenceId="PARAM_VALUE.Vendor_ID">10EE'
+    xci.write_text(original, encoding="utf-8")
+
+    class _Donor:
+        vendor_id = 0x1B21
+        device_id = 0x1060
+        subsystem_vendor_id = 0x1043
+        subsystem_id = 0x8730
+
+    summary = patch_xci_donor_ids(tmp_path, _Donor(), class_code=0x010601)
+    assert summary.num_patched == 0
+    assert "pcie_7x_0.xci" in summary.failed
+    assert xci.read_text(encoding="utf-8") == original
 
 
 def test_xci_patch_summary_helpers():


### PR DESCRIPTION
## Summary

Follow-up to #624. Extends XCI donor-ID patching to **XML-format** XCI files. Previously `patch_xci_donor_ids()` only matched JSON-format XCIs, so XML-format boards (pciescreamer, acorn_ft2232h, NeTV2) logged a "matched zero fields" warning instead of getting their PCIe placeholder IDs (`10EE`/`0666`/`020000`) rewritten with donor IDs before Vivado opens the project.

## Changes

- **`src/vivado_handling/ip_lock_resolver.py`** — `patch_xci_donor_ids()` now handles both XML- and JSON-format XCI files:
  - Byte sniff to detect format, then format-aware regex substitution over both `PARAM_VALUE` and `MODELPARAM_VALUE` blocks for XML.
  - ElementTree validation of the patched output so malformed rewrites are caught.
  - Returns a richer `XciPatchSummary` (patched / unmatched / failed) instead of a bare int.
- **`tests/test_ip_lock_resolver.py`** — adds coverage for XML-format patching, including a real NeTV2 fixture, plus the existing JSON path.
- **`docs/superpowers/specs/2026-05-29-xci-xml-donor-ids-design.md`** — design spec.

## Testing

- Full non-e2e suite passes (XCI patch tests + regressions).
- Validated against a real NeTV2 `pcie_7x_0.xci` fixture.

Closes the XML-format gap noted in #622 / #624.
