### PR TITLE
fix: address CodeQL/AI quality findings

### DIFF
--- a/src/device_clone/pcileech_context.py
+++ b/src/device_clone/pcileech_context.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-from __future__ import annotations
-
 """PCILeech template context builder."""
+
+from __future__ import annotations
 
 import ctypes
 import fcntl
@@ -1926,7 +1926,6 @@ class PCILeechContextBuilder:
                     vfio_region_index = bar_data.get("index", bar_data.get("bar", i))
                 elif isinstance(bar_data, BarInfo):
                     vfio_region_index = bar_data.index
-                    vfio_region_index = getattr(bar_data, "index")
 
                 bar_info = self._get_vfio_bar_info(vfio_region_index, bar_data)
                 if bar_info:

--- a/src/vivado_handling/fifo_donor_patcher.py
+++ b/src/vivado_handling/fifo_donor_patcher.py
@@ -8,7 +8,7 @@ so the FIFO's runtime control register keeps Xilinx defaults forever (the
 upstream comments mark these slots ``(NOT IMPLEMENTED)`` in software).
 
 This module rewrites those literals deterministically as a post-copy step. It
-also commented-outs the five ``assign dpcie.pcie_cfg_*`` lines that exist only
+also comments out the five ``assign dpcie.pcie_cfg_*`` lines that exist only
 in the CaptainDMA/75t484_x1 fifo but reference fields the matching
 ``IfPCIeFifoCore`` interface never declares — that mismatch is what makes
 75t484_x1 fail synthesis with ``cannot resolve hierarchical name``.

--- a/tests/test_pcileech_generator_fixes.py
+++ b/tests/test_pcileech_generator_fixes.py
@@ -516,15 +516,12 @@ def test_bar_coercion_handles_attribute_based_format(generator):
 
 
 def test_future_annotations_import():
-    """Test that future annotations import is present for Python 3.8 compat."""
+    """Test that the module compiles with `from __future__ import annotations`."""
     import pcileechfwgenerator.device_clone.pcileech_generator as module
-    import sys
-    
-    # Check if __future__ annotations are enabled
-    if sys.version_info >= (3, 8):
-        # The module should compile without errors
-        assert module.PCILeechGenerator is not None
-        assert module.PCILeechGenerationConfig is not None
+
+    # The module should compile and expose its public types without errors
+    assert module.PCILeechGenerator is not None
+    assert module.PCILeechGenerationConfig is not None
 
 
 def test_contextmanager_import_at_module_level():


### PR DESCRIPTION
Reviews the AI/CodeQL quality findings surfaced on the security dashboard and applies the ones that hold up.

## Applied
- **`pcileech_context.py`** — module docstring sat *after* `from __future__ import annotations`, so it was a no-op expression and `__doc__` resolved to `None`. Moved it above the future import (the only statement allowed to precede a `__future__` import). Also removed a redundant `vfio_region_index = getattr(bar_data, "index")` line that immediately re-assigned the identical value set on the prior line (`BarInfo.index` is a required dataclass field, so no fallback default was needed).
- **`fifo_donor_patcher.py`** — grammar fix in module docstring ("commented-outs" → "comments out").
- **`test_pcileech_generator_fixes.py`** — dropped a dead `sys.version_info >= (3, 8)` guard. The project requires Python ≥ 3.11, so the guard was always true; removed it (and the stale "3.8 compat" wording) and run the assertions unconditionally.

## Reviewed and rejected (false positives)
- **Class-code byte order** (`collector.py` et al.) — finding claimed `int.from_bytes(cfg[9:12], "little")` should be `"big"`. It's backwards: PCI lays out prog-IF/subclass/base at offsets 0x09/0x0A/0x0B, and little-endian correctly yields the conventional `0xBBSSPP` (e.g. Ethernet `0x020000`); `"big"` would invert it to `0x000002`. It would also desync from the write side, which uses `to_bytes(3, "little")`. No change.
- **`tmp_path` in `test_vivado_cmd_quoting.py`** — finding flagged a hardcoded `/tmp/foo bar/...` path as a filesystem dependency. The tests are pure `shlex` string round-trips (and the subprocess call is monkeypatched); nothing touches disk. No change.