### PR TITLE
feat(bar): serve donor register BAR at its real PCI index (#613)

### DIFF
--- a/src/device_clone/pcileech_context.py
+++ b/src/device_clone/pcileech_context.py
@@ -2005,12 +2005,32 @@ class PCILeechContextBuilder:
         return max(memory_bars, key=lambda b: b.size)
 
     def _build_bar_config_dict(self, primary_bar, bar_configs):
+        # Gap C — donor-BAR-index serving. The generated firmware serves the
+        # donor's primary register (MMIO) BAR at its REAL PCI BAR index N: the
+        # controller gates the device impl on rd_req_bar[N]/wr_bar[N], the IP
+        # enables CONFIG.Bar{N}_*, and the cfgspace shadow places the BAR at
+        # slot N (see pcie_ip_donor_override.py and pcileech_cfgspace.coe.j2).
+        #
+        # ``served`` is the primary BAR chosen by _select_primary_bar (largest
+        # MMIO). ``served_bar_index`` is its donor PCI index N (gating / IP /
+        # cfgspace / overlay key). ``primary_bar`` is its position within the
+        # filtered ``bars`` list so ``bars[primary_bar]`` still resolves to it.
+        served = primary_bar
+        # Identity (is), not equality: list.index() would return the first
+        # value-equal entry, which could be a different BAR if two compared
+        # equal. primary_bar is always a reference to an element of bar_configs.
+        served_pos = next(
+            (i for i, b in enumerate(bar_configs) if b is served), 0
+        )
         return {
-            "bar_index": primary_bar.index,
-            "aperture_size": primary_bar.size,
-            "bar_type": primary_bar.bar_type,
-            "prefetchable": primary_bar.prefetchable,
-            "memory_type": "memory" if primary_bar.is_memory else "io",
+            "primary_bar": served_pos,
+            "served_bar_index": served.index,
+            "served_is_64bit": bool(served.is_64bit),
+            "bar_index": served.index,
+            "aperture_size": served.size,
+            "bar_type": served.bar_type,
+            "prefetchable": served.prefetchable,
+            "memory_type": "memory" if served.is_memory else "io",
             "bars": bar_configs,
         }
 

--- a/src/templates/sv/pcileech_cfgspace.coe.j2
+++ b/src/templates/sv/pcileech_cfgspace.coe.j2
@@ -45,13 +45,8 @@ True
 00000000,
   {% endif %}
 {% else %}
-  {% if not (bar_config is defined and bar_config.bars is defined and bar_config.bars|length > 0) %}
 ; {{ bar_name }}: Disabled (not configured)
 00000000,
-  {% else %}
-; {{ bar_name }}: Disabled (not configured)
-00000000,
-  {% endif %}
 {% endif %}
 {% endmacro %}
 
@@ -108,58 +103,27 @@ memory_initialization_vector=
 00001010,
 
 ; Base Address Registers (0x10-0x27)
+{# Gap C — render the single served register BAR at its real donor PCI index.
+   The IP enables only that BAR (pcie_ip_donor_override disables the rest), so
+   every other slot is zeroed here too. A 64-bit served BAR places its all-ones
+   upper dword at slot N+1. Replaces the old positional rendering (which also
+   wrongly hardcoded slot 2 as IO). #}
 {% set bars = (bar_config.bars if (bar_config is defined and bar_config.bars is defined) else []) %}
-{% set has_bars = (bars | length) > 0 %}
-
-; BAR0 (0x10-0x13) - Memory BAR
-{% if has_bars %}
-{{ render_bar(0, bars[0]) }}
-{% else %}
-{{ render_bar(0) }}
-{% endif %}
-
-; BAR1 (0x14-0x17) - Upper 32 bits for 64-bit BAR or second BAR
-{% if has_bars and (bars[0].is_64bit if bars|length > 0 and (bars[0] is not none) else False) %}
-; BAR1: Upper 32 bits of 64-bit BAR0
+{% set _served_pos = (bar_config.primary_bar | default(0)) if bar_config is defined else 0 %}
+{% set _served_idx = (bar_config.served_bar_index | default(0)) if bar_config is defined else 0 %}
+{% set _served_bar = bars[_served_pos] if (bars | length) > _served_pos else None %}
+{% set _served_64 = (bar_config.served_is_64bit | default(false)) if bar_config is defined else false %}
+{% for slot in range(6) %}
+{% if _served_bar is not none and slot == _served_idx %}
+{{ render_bar(slot, _served_bar) }}
+{% elif _served_bar is not none and _served_64 and slot == (_served_idx + 1) %}
+; BAR{{ slot }} (0x{{ '%02X' % (0x10 + slot * 4) }}): Upper 32 bits of 64-bit BAR{{ _served_idx }}
 FFFFFFFF,
-{% elif has_bars and bars|length > 1 %}
-{{ render_bar(1, bars[1]) }}
 {% else %}
-; BAR1: Disabled (not configured)
+; BAR{{ slot }} (0x{{ '%02X' % (0x10 + slot * 4) }}): Disabled
 00000000,
 {% endif %}
-
-; BAR2 (0x18-0x1B) - I/O BAR or third memory BAR
-{% if has_bars and bars|length > 2 %}
-{{ render_bar(2, bars[2], true) }}
-{% else %}
-; BAR2: Disabled (not configured)
-00000000,
-{% endif %}
-
-; BAR3 (0x1C-0x1F) - Fourth BAR
-{% if has_bars and bars|length > 3 %}
-{{ render_bar(3, bars[3]) }}
-{% else %}
-; BAR3: Disabled (not configured)
-00000000,
-{% endif %}
-
-; BAR4 (0x20-0x23) - Fifth BAR
-{% if has_bars and bars|length > 4 %}
-{{ render_bar(4, bars[4]) }}
-{% else %}
-; BAR4: Disabled (not configured)
-00000000,
-{% endif %}
-
-; BAR5 (0x24-0x27) - Sixth BAR
-{% if has_bars and bars|length > 5 %}
-{{ render_bar(5, bars[5]) }}
-{% else %}
-; BAR5: Disabled (not configured)
-00000000,
-{% endif %}
+{% endfor %}
 
 ; Cardbus CIS Pointer (0x28-0x2B) - Unused
 00000000,
@@ -454,8 +418,8 @@ FFFFFFFF,
 ;
 ; BAR Configuration (using safe defaults when values are missing):
 {# Use safe_attr to avoid TemplateObject attribute errors during migration #}
-{% set primary_bar_index = safe_attr(bar_config, 'bar_index', 0) %}
-; - Primary BAR Index: {{ primary_bar_index }}
+{% set served_bar_index = safe_attr(bar_config, 'served_bar_index', safe_attr(bar_config, 'bar_index', 0)) %}
+; - Served BAR Index: {{ served_bar_index }}
 {% set aperture_size = safe_attr(bar_config, 'aperture_size', 0) %}
 ; - Aperture Size: {{ aperture_size }} bytes
 {% set bar_type = safe_attr(bar_config, 'bar_type', 0) %}

--- a/src/templates/sv/pcileech_tlps128_bar_controller.sv.j2
+++ b/src/templates/sv/pcileech_tlps128_bar_controller.sv.j2
@@ -164,145 +164,58 @@ module pcileech_tlps128_bar_controller(
     assign rd_rsp_valid = bar_rsp_valid[0] || bar_rsp_valid[1] || bar_rsp_valid[2] || bar_rsp_valid[3] || bar_rsp_valid[4] || bar_rsp_valid[5] || bar_rsp_valid[6];
 {% endif %}
     
-{% if bar_config and bar_config.get('bar_models') %}
-    // ========================================================================
-    // Device-Specific BAR Implementation (learned from donor device)
-    // ========================================================================
-    
-    // Primary BAR uses device-specific implementation
-    pcileech_bar_impl_device #(
-        .BAR_SIZE       ( {{ bar_config.bars[bar_config.primary_bar|default(0)].size if bar_config.bars else 4096 }} )
-    ) i_bar0(
-        .rst            ( rst                           ),
+{#
+    Gap C — donor-BAR-index serving. The donor's primary register window is
+    served at its REAL PCI BAR index (served_bar_index); every other slot is a
+    non-responding stub (pcileech_bar_impl_none), with loopaddr kept at slot 1
+    when free for test/diagnostics. A 64-bit served BAR lights two adjacent hit
+    bits (N and N+1), so slot N+1 MUST be `none` — never loopaddr — or the
+    response mux would be double-driven. When served_bar_index == 0 and 32-bit
+    this reproduces the historical wiring (device@0, loopaddr@1, none@2..6).
+#}
+{% set _served = (bar_config.served_bar_index | default(0)) if bar_config else 0 %}
+{% set _served64 = (bar_config.served_is_64bit | default(false)) if bar_config else false %}
+{% set _has_model = (bar_config and bar_config.get('bar_models')) %}
+{% set _bar_size = (bar_config.aperture_size | default(4096)) if bar_config else 4096 %}
+{% macro bar_inst(module, k, inst, param_size=None) -%}
+{% if param_size is not none %}    {{ module }} #(
+        .BAR_SIZE       ( {{ param_size }} )
+    ) {{ inst }}(
+{% else %}    {{ module }} {{ inst }}(
+{% endif %}        .rst            ( rst                           ),
         .clk            ( clk                           ),
         .wr_addr        ( wr_addr                       ),
         .wr_be          ( wr_be                         ),
         .wr_data        ( wr_data                       ),
-        .wr_valid       ( wr_valid && wr_bar[0]         ),
+        .wr_valid       ( wr_valid && wr_bar[{{ k }}]         ),
         .rd_req_ctx     ( rd_req_ctx                    ),
         .rd_req_addr    ( rd_req_addr                   ),
-        .rd_req_valid   ( rd_req_valid && rd_req_bar[0] ),
-        .rd_rsp_ctx     ( bar_rsp_ctx[0]                ),
-        .rd_rsp_data    ( bar_rsp_data[0]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[0]              )
+        .rd_req_valid   ( rd_req_valid && rd_req_bar[{{ k }}] ),
+        .rd_rsp_ctx     ( bar_rsp_ctx[{{ k }}]                ),
+        .rd_rsp_data    ( bar_rsp_data[{{ k }}]               ),
+        .rd_rsp_valid   ( bar_rsp_valid[{{ k }}]              )
     );
+{%- endmacro %}
+    // ========================================================================
+    // BAR implementations (served register window at BAR index {{ _served }})
+    // ========================================================================
+{% for k in range(7) %}
+{% if k == _served %}
+{% if _has_model %}
+{{ bar_inst('pcileech_bar_impl_device', k, 'i_bar' ~ k, param_size=_bar_size) }}
 {% else %}
-    // ========================================================================
-    // Generic BAR Implementation (no learned model available)
-    // ========================================================================
-    
-    // BAR0: Zero-initialized read/write BAR (4KB default)
-    pcileech_bar_impl_zerowrite4k i_bar0(
-        .rst            ( rst                           ),
-        .clk            ( clk                           ),
-        .wr_addr        ( wr_addr                       ),
-        .wr_be          ( wr_be                         ),
-        .wr_data        ( wr_data                       ),
-        .wr_valid       ( wr_valid && wr_bar[0]         ),
-        .rd_req_ctx     ( rd_req_ctx                    ),
-        .rd_req_addr    ( rd_req_addr                   ),
-        .rd_req_valid   ( rd_req_valid && rd_req_bar[0] ),
-        .rd_rsp_ctx     ( bar_rsp_ctx[0]                ),
-        .rd_rsp_data    ( bar_rsp_data[0]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[0]              )
-    );
+{{ bar_inst('pcileech_bar_impl_zerowrite4k', k, 'i_bar' ~ k) }}
 {% endif %}
-    
-    // ========================================================================
-    // Additional BARs (use generic implementations)
-    // ========================================================================
-    
-    // BAR1: Address loopback (useful for testing)
-    pcileech_bar_impl_loopaddr i_bar1(
-        .rst            ( rst                           ),
-        .clk            ( clk                           ),
-        .wr_addr        ( wr_addr                       ),
-        .wr_be          ( wr_be                         ),
-        .wr_data        ( wr_data                       ),
-        .wr_valid       ( wr_valid && wr_bar[1]         ),
-        .rd_req_ctx     ( rd_req_ctx                    ),
-        .rd_req_addr    ( rd_req_addr                   ),
-        .rd_req_valid   ( rd_req_valid && rd_req_bar[1] ),
-        .rd_rsp_ctx     ( bar_rsp_ctx[1]                ),
-        .rd_rsp_data    ( bar_rsp_data[1]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[1]              )
-    );
-    
-    // BAR2-6: Unimplemented
-    pcileech_bar_impl_none i_bar2(
-        .rst            ( rst                           ),
-        .clk            ( clk                           ),
-        .wr_addr        ( wr_addr                       ),
-        .wr_be          ( wr_be                         ),
-        .wr_data        ( wr_data                       ),
-        .wr_valid       ( wr_valid && wr_bar[2]         ),
-        .rd_req_ctx     ( rd_req_ctx                    ),
-        .rd_req_addr    ( rd_req_addr                   ),
-        .rd_req_valid   ( rd_req_valid && rd_req_bar[2] ),
-        .rd_rsp_ctx     ( bar_rsp_ctx[2]                ),
-        .rd_rsp_data    ( bar_rsp_data[2]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[2]              )
-    );
-    
-    pcileech_bar_impl_none i_bar3(
-        .rst            ( rst                           ),
-        .clk            ( clk                           ),
-        .wr_addr        ( wr_addr                       ),
-        .wr_be          ( wr_be                         ),
-        .wr_data        ( wr_data                       ),
-        .wr_valid       ( wr_valid && wr_bar[3]         ),
-        .rd_req_ctx     ( rd_req_ctx                    ),
-        .rd_req_addr    ( rd_req_addr                   ),
-        .rd_req_valid   ( rd_req_valid && rd_req_bar[3] ),
-        .rd_rsp_ctx     ( bar_rsp_ctx[3]                ),
-        .rd_rsp_data    ( bar_rsp_data[3]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[3]              )
-    );
-    
-    pcileech_bar_impl_none i_bar4(
-        .rst            ( rst                           ),
-        .clk            ( clk                           ),
-        .wr_addr        ( wr_addr                       ),
-        .wr_be          ( wr_be                         ),
-        .wr_data        ( wr_data                       ),
-        .wr_valid       ( wr_valid && wr_bar[4]         ),
-        .rd_req_ctx     ( rd_req_ctx                    ),
-        .rd_req_addr    ( rd_req_addr                   ),
-        .rd_req_valid   ( rd_req_valid && rd_req_bar[4] ),
-        .rd_rsp_ctx     ( bar_rsp_ctx[4]                ),
-        .rd_rsp_data    ( bar_rsp_data[4]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[4]              )
-    );
-    
-    pcileech_bar_impl_none i_bar5(
-        .rst            ( rst                           ),
-        .clk            ( clk                           ),
-        .wr_addr        ( wr_addr                       ),
-        .wr_be          ( wr_be                         ),
-        .wr_data        ( wr_data                       ),
-        .wr_valid       ( wr_valid && wr_bar[5]         ),
-        .rd_req_ctx     ( rd_req_ctx                    ),
-        .rd_req_addr    ( rd_req_addr                   ),
-        .rd_req_valid   ( rd_req_valid && rd_req_bar[5] ),
-        .rd_rsp_ctx     ( bar_rsp_ctx[5]                ),
-        .rd_rsp_data    ( bar_rsp_data[5]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[5]              )
-    );
-    
-    pcileech_bar_impl_none i_bar6_optrom(
-        .rst            ( rst                           ),
-        .clk            ( clk                           ),
-        .wr_addr        ( wr_addr                       ),
-        .wr_be          ( wr_be                         ),
-        .wr_data        ( wr_data                       ),
-        .wr_valid       ( wr_valid && wr_bar[6]         ),
-        .rd_req_ctx     ( rd_req_ctx                    ),
-        .rd_req_addr    ( rd_req_addr                   ),
-        .rd_req_valid   ( rd_req_valid && rd_req_bar[6] ),
-        .rd_rsp_ctx     ( bar_rsp_ctx[6]                ),
-        .rd_rsp_data    ( bar_rsp_data[6]               ),
-        .rd_rsp_valid   ( bar_rsp_valid[6]              )
-    );
+{% elif _served64 and k == _served + 1 %}
+{{ bar_inst('pcileech_bar_impl_none', k, 'i_bar' ~ k) }}
+{% elif k == 1 %}
+{{ bar_inst('pcileech_bar_impl_loopaddr', k, 'i_bar' ~ k) }}
+{% elif k == 6 %}
+{{ bar_inst('pcileech_bar_impl_none', k, 'i_bar6_optrom') }}
+{% else %}
+{{ bar_inst('pcileech_bar_impl_none', k, 'i_bar' ~ k) }}
+{% endif %}
+{% endfor %}
 
 
 endmodule

--- a/src/templating/sv_overlay_generator.py
+++ b/src/templating/sv_overlay_generator.py
@@ -398,8 +398,12 @@ class SVOverlayGenerator:
         )
         
         try:
-            # Find the primary BAR model (usually BAR0, but can be configured)
-            primary_bar_idx = bar_config.get("primary_bar", 0)
+            # Find the served BAR's model. bar_models is keyed by donor PCI BAR
+            # index, so look up by served_bar_index (gap C); fall back to the
+            # legacy primary_bar key, then 0.
+            primary_bar_idx = bar_config.get(
+                "served_bar_index", bar_config.get("primary_bar", 0)
+            )
             bar_model = None
             
             if isinstance(bar_models_data, dict):

--- a/src/vivado_handling/pcie_ip_donor_override.py
+++ b/src/vivado_handling/pcie_ip_donor_override.py
@@ -17,9 +17,10 @@ Coverage as of Step 3 (see docs/superpowers/plans/2026-05-*-pcie-ip-donor-overri
 
 - closed end-to-end: Class_Code (A4), MSI-X (A6), LinkCap (A7), MPS (A8),
   AER (C1), DSN (C2), ARI (C3), Cpl_Timeout (D2), served BAR aperture (A5)
-- A5 scope: only the single served BAR is mirrored, presented as config-space
-  BAR0 (the one window the PCILeech controller answers). Multi-BAR layout
-  fidelity and donors whose served window isn't BAR0 are out of scope.
+- A5/C scope: only the single served register BAR is mirrored, emitted at its
+  real donor PCI index N (CONFIG.Bar{N}_*) with every other index disabled, so
+  the host enumerates exactly that one window. Full multi-BAR layout fidelity is
+  out of scope.
 - not yet implemented: UltraScale+ IP property names. The emitter targets the
   Xilinx 7-series IP property schema only.
 

--- a/src/vivado_handling/pcie_ip_donor_override.py
+++ b/src/vivado_handling/pcie_ip_donor_override.py
@@ -16,10 +16,12 @@ change reaches the synthesizable HDL. It is wired in by appending a guarded
 Coverage as of Step 3 (see docs/superpowers/plans/2026-05-*-pcie-ip-donor-override-*.md):
 
 - closed end-to-end: Class_Code (A4), MSI-X (A6), LinkCap (A7), MPS (A8),
-  AER (C1), DSN (C2), ARI (C3), Cpl_Timeout (D2)
-- not yet implemented: BAR Type/Size emission (gap A5), UltraScale+ IP
-  property names. The emitter targets the Xilinx 7-series IP property
-  schema only.
+  AER (C1), DSN (C2), ARI (C3), Cpl_Timeout (D2), served BAR aperture (A5)
+- A5 scope: only the single served BAR is mirrored, presented as config-space
+  BAR0 (the one window the PCILeech controller answers). Multi-BAR layout
+  fidelity and donors whose served window isn't BAR0 are out of scope.
+- not yet implemented: UltraScale+ IP property names. The emitter targets the
+  Xilinx 7-series IP property schema only.
 
 Note on DSN: sv_context_builder.py also writes ``device_serial_number_int``
 into an ``enhanced_context`` dict (separate from template_context) used for
@@ -33,6 +35,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
+
+from pcileechfwgenerator.utils.validators import get_bar_size_validator
 
 from .fifo_donor_patcher import DonorIDs, _coerce_int
 
@@ -84,6 +88,15 @@ class DonorPCIeIPConfig:
     # C2 — Device Serial Number (64-bit; emitted as two 32-bit halves into the IP)
     dsn_value: Optional[int] = None
 
+    # A5 — served BAR aperture, presented as config-space BAR0 (the only window
+    # the PCILeech controller services). Setting bar_aperture_size enables the
+    # block; the rest default sensibly. See docs/plans/firmware-fidelity-gaps.md.
+    bar_aperture_size: Optional[int] = None  # bytes, power of 2
+    bar_is_memory: Optional[bool] = None  # True=Memory (default), False=IO
+    bar_is_64bit: Optional[bool] = None  # memory only; consumes the next slot
+    bar_prefetchable: Optional[bool] = None  # memory only
+    bar_index: Optional[int] = None  # donor PCI BAR index N the device serves
+
 
 _OVERRIDE_FILENAME = "pcileech_donor_ip_overrides.tcl"
 # Use ``file join`` so paths containing spaces don't tokenize incorrectly
@@ -128,6 +141,28 @@ def generate_pcie_ip_override_tcl(
         f"    generate_target -force all [get_ips {ip_name}]\n"
         "}\n"
     )
+
+
+_XILINX_BAR_SCALES = (
+    ("Gigabytes", 1024 * 1024 * 1024),
+    ("Megabytes", 1024 * 1024),
+    ("Kilobytes", 1024),
+    ("Bytes", 1),
+)
+
+
+def _bytes_to_xilinx_scale_size(size_bytes: int) -> "tuple[str, int]":
+    """Map a byte size to the 7-series IP's ``(Scale, Size)`` token pair.
+
+    Picks the largest scale that divides ``size_bytes`` evenly so the numeric
+    multiplier stays below 1024 — the same Scale/Size split the Vivado IP GUI
+    uses (e.g. 2 MiB is ``Megabytes 2``, never ``Kilobytes 2048``).
+    """
+    for scale, unit in _XILINX_BAR_SCALES:
+        if size_bytes % unit == 0:
+            return (scale, size_bytes // unit)
+    # Unreachable: the ("Bytes", 1) tier divides every integer.
+    raise ValueError(f"cannot encode BAR size {size_bytes} bytes")
 
 
 _MPS_TOKENS = {
@@ -272,7 +307,86 @@ def _format_extra_config_lines(extra: "DonorPCIeIPConfig") -> list[str]:
         out.append(f"CONFIG.DSN_HEX1 {lower:08X}")
         out.append(f"CONFIG.DSN_HEX2 {upper:08X}")
 
+    out.extend(_format_bar_aperture_lines(extra))
+
     return out
+
+
+def _bar_aperture_error(size: int, is_memory: bool) -> "str | None":
+    """Return an error string if *size* can't be a valid BAR aperture, else None.
+
+    Shared by the emitter (which raises on explicit misuse) and the extractor
+    (which skips defensively, leaving the IP default rather than failing a build).
+    """
+    bar_type = "memory" if is_memory else "io"
+    result = get_bar_size_validator(bar_type=bar_type).validate(size)
+    if not result.valid:
+        return (
+            f"BAR aperture size {size} is invalid for a {bar_type} BAR: "
+            + "; ".join(result.errors)
+        )
+    # Sub-page memory apertures wrap in the hard block; PCILeech's own guidance
+    # is to never go below 4 KiB for the served memory BAR.
+    if is_memory and size < 4096:
+        return f"BAR aperture size {size} below the 4 KiB floor for a memory BAR"
+    return None
+
+
+_NUM_STANDARD_BARS = 6  # BAR0..BAR5
+
+
+def _format_bar_aperture_lines(extra: "DonorPCIeIPConfig") -> list[str]:
+    """Emit the ``CONFIG.Bar{N}_*`` block for the served donor BAR (gaps A5/C).
+
+    The device register window is served at the donor's REAL PCI BAR index N
+    (``bar_index``) — the controller gates its impl on rd_req_bar[N]/wr_bar[N]
+    to match. IO BARs cannot be 64-bit or prefetchable, so those flags are
+    coerced off. Every other standard BAR index is force-disabled (including the
+    .xci default BAR0 when N != 0) so the host enumerates exactly the one served
+    window — no phantom BARs, and no BAR the controller answers with ``none``
+    (which would hang reads). A 64-bit BAR consumes index N+1, which falls into
+    the disabled set automatically.
+    """
+    if extra.bar_aperture_size is None:
+        return []
+
+    size = extra.bar_aperture_size
+    is_memory = True if extra.bar_is_memory is None else bool(extra.bar_is_memory)
+
+    error = _bar_aperture_error(size, is_memory)
+    if error is not None:
+        raise ValueError(error)
+
+    n = 0 if extra.bar_index is None else extra.bar_index
+    if not (0 <= n < _NUM_STANDARD_BARS):
+        raise ValueError(f"bar_index {n} is not a standard BAR index (0..5)")
+
+    is_64bit = bool(extra.bar_is_64bit) and is_memory
+    if is_64bit and n == _NUM_STANDARD_BARS - 1:
+        # The upper half would land on BAR6 (Expansion ROM), not a standard
+        # BAR — electrically invalid PCI.
+        raise ValueError(
+            f"bar_index {n} cannot be 64-bit: the upper-half partner would be "
+            "BAR6 (Expansion ROM), not a standard BAR"
+        )
+    prefetchable = bool(extra.bar_prefetchable) and is_memory
+    scale, multiplier = _bytes_to_xilinx_scale_size(size)
+
+    lines = [
+        f"CONFIG.Bar{n}_Enabled true",
+        f"CONFIG.Bar{n}_Type {'Memory' if is_memory else 'IO'}",
+        f"CONFIG.Bar{n}_64bit {_tcl_bool(is_64bit)}",
+        f"CONFIG.Bar{n}_Prefetchable {_tcl_bool(prefetchable)}",
+        f"CONFIG.Bar{n}_Scale {scale}",
+        f"CONFIG.Bar{n}_Size {multiplier}",
+    ]
+    # Disable every other standard BAR (incl. the 64-bit partner at N+1).
+    lines.extend(
+        f"CONFIG.Bar{k}_Enabled false"
+        for k in range(_NUM_STANDARD_BARS)
+        if k != n
+    )
+    return lines
 
 
 def _find_generate_project_scripts(staging_dir: Path) -> List[Path]:
@@ -407,6 +521,14 @@ def donor_pcie_ip_config_from_result(result: dict) -> "DonorPCIeIPConfig":
             msix_pba_bir = candidate_pba_bir
             msix_pba_offset = candidate_pba_off
 
+    (
+        bar_aperture_size,
+        bar_is_memory,
+        bar_is_64bit,
+        bar_prefetchable,
+        bar_index,
+    ) = _served_bar_from_context(template_context)
+
     return DonorPCIeIPConfig(
         class_code=class_code,
         max_payload_size=max_payload_size,
@@ -423,4 +545,68 @@ def donor_pcie_ip_config_from_result(result: dict) -> "DonorPCIeIPConfig":
         cpl_timeout_ranges=cpl_ranges,
         cpl_timeout_disable_supported=cpl_disable,
         dsn_value=dsn_value,
+        bar_aperture_size=bar_aperture_size,
+        bar_is_memory=bar_is_memory,
+        bar_is_64bit=bar_is_64bit,
+        bar_prefetchable=bar_prefetchable,
+        bar_index=bar_index,
+    )
+
+
+def _attr_or_key(obj, name, default=None):
+    """Read ``name`` from an object attribute or a mapping key (defensive)."""
+    if obj is None:
+        return default
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _served_bar_from_context(template_context: dict):
+    """Extract the served BAR's (size, is_memory, is_64bit, prefetchable).
+
+    Anchors on the SAME entry the BAR controller serves —
+    ``bars[primary_bar|default(0)]`` (see pcileech_tlps128_bar_controller.sv.j2)
+    — so the emitted IP aperture is guaranteed to match the controller's
+    ``BAR_SIZE``. Returns all-None when the served BAR can't be read, leaving
+    the Xilinx IP default in place rather than emitting a bad aperture.
+    """
+    none5 = (None, None, None, None, None)
+    bar_config = template_context.get("bar_config") or {}
+    bars = _attr_or_key(bar_config, "bars") or []
+    # ``primary_bar`` is the list position of the served BAR within ``bars``;
+    # the controller indexes the same way (bars[primary_bar]).
+    index = _coerce_int(_attr_or_key(bar_config, "primary_bar", 0)) or 0
+    if index >= len(bars):
+        return none5
+
+    served = bars[index]
+    size = _coerce_int(_attr_or_key(served, "size"))
+    if not size:
+        return none5
+
+    is_io = bool(_attr_or_key(served, "is_io", False))
+    is_memory = _attr_or_key(served, "is_memory", None)
+    if is_memory is None:
+        is_memory = not is_io
+    is_memory = bool(is_memory)
+
+    # Defensive: don't propagate an aperture the emitter would reject — leave
+    # the Xilinx IP default in place instead of failing the build.
+    if _bar_aperture_error(size, is_memory) is not None:
+        return none5
+
+    # Served donor PCI index N: prefer the explicit bar_config key, else the
+    # served BAR's own .index. This is the slot the controller gates on and the
+    # IP enables (CONFIG.Bar{N}_*).
+    served_index = _coerce_int(_attr_or_key(bar_config, "served_bar_index", None))
+    if served_index is None:
+        served_index = _coerce_int(_attr_or_key(served, "index", 0)) or 0
+
+    return (
+        size,
+        is_memory,
+        bool(_attr_or_key(served, "is_64bit", False)),
+        bool(_attr_or_key(served, "prefetchable", False)),
+        served_index,
     )

--- a/tests/test_bar_controller_index_serving.py
+++ b/tests/test_bar_controller_index_serving.py
@@ -1,0 +1,113 @@
+"""Controller renders the device BAR impl at the donor's real BAR index (gap C).
+
+The PCILeech BAR controller historically hard-wired the device register
+implementation to slot 0 (i_bar0, hit bit 0). For donors whose primary register
+BAR is not index 0, the device impl must be gated on rd_req_bar[N]/wr_bar[N] for
+the served donor index N, and every other slot must be a non-responding stub
+(plus loopaddr at slot 1 when free). A 64-bit served BAR consumes slot N+1, so
+that partner slot must be `none` — never `loopaddr` — to avoid double-driving
+the response mux.
+"""
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent.resolve()
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from pcileechfwgenerator.templating.template_renderer import TemplateRenderer
+
+TEMPLATE = "sv/pcileech_tlps128_bar_controller.sv.j2"
+
+
+def _ctx(served_index, *, is_64bit=False, aperture=65536, with_model=True):
+    bar_config = {
+        "served_bar_index": served_index,
+        "served_is_64bit": is_64bit,
+        "aperture_size": aperture,
+        "primary_bar": 0,
+        "bars": [{"size": aperture}],
+    }
+    if with_model:
+        bar_config["bar_models"] = {str(served_index): {"size": aperture}}
+    return {
+        "header": "// test",
+        "device_signature": "1234:5678",
+        "bar_config": bar_config,
+    }
+
+
+def _device_inst_slot(rendered):
+    """Return the BAR slot index the device/zerowrite register impl is gated on."""
+    # The served impl is pcileech_bar_impl_device (model) or _zerowrite4k.
+    m = re.search(
+        r"pcileech_bar_impl_(?:device|zerowrite4k)\b.*?rd_req_bar\[(\d+)\]",
+        rendered,
+        re.DOTALL,
+    )
+    return int(m.group(1)) if m else None
+
+
+def _impl_for_slot(rendered, k):
+    """Return the impl module name instantiated for rd_req_bar[k]."""
+    m = re.search(
+        r"(pcileech_bar_impl_\w+)\b[^;]*?rd_req_bar\[" + str(k) + r"\]",
+        rendered,
+        re.DOTALL,
+    )
+    return m.group(1) if m else None
+
+
+@pytest.fixture
+def renderer():
+    return TemplateRenderer()
+
+
+class TestControllerIndexServing:
+    def test_served_index_2_gates_device_on_bit_2(self, renderer):
+        out = renderer.render_template(TEMPLATE, _ctx(2))
+        assert _device_inst_slot(out) == 2
+        # slot 0 must be a non-responding stub now (not the device impl)
+        assert _impl_for_slot(out, 0) == "pcileech_bar_impl_none"
+
+    def test_served_index_2_uses_aperture_for_bar_size(self, renderer):
+        out = renderer.render_template(TEMPLATE, _ctx(2, aperture=65536))
+        assert re.search(r"BAR_SIZE\s*\(\s*65536\s*\)", out)
+
+    def test_index_0_backcompat_device_on_bit0_loopaddr_on_bit1(self, renderer):
+        out = renderer.render_template(TEMPLATE, _ctx(0))
+        assert _device_inst_slot(out) == 0
+        assert _impl_for_slot(out, 1) == "pcileech_bar_impl_loopaddr"
+        assert _impl_for_slot(out, 2) == "pcileech_bar_impl_none"
+
+    def test_64bit_served_at_0_makes_partner_slot1_none_not_loopaddr(self, renderer):
+        # Latent-bug fix: a 64-bit BAR0 lights hit bits 0 and 1; slot 1 must not
+        # respond, so it must be `none`, not the default loopaddr.
+        out = renderer.render_template(TEMPLATE, _ctx(0, is_64bit=True))
+        assert _impl_for_slot(out, 1) == "pcileech_bar_impl_none"
+
+    def test_64bit_served_at_2_makes_partner_slot3_none(self, renderer):
+        out = renderer.render_template(TEMPLATE, _ctx(2, is_64bit=True))
+        assert _impl_for_slot(out, 3) == "pcileech_bar_impl_none"
+
+    def test_served_index_1_replaces_loopaddr(self, renderer):
+        # Slot 1 is the only slot with a non-`none` default (loopaddr); when the
+        # served BAR IS index 1, the device impl must take it and loopaddr must
+        # not also be emitted there (single driver).
+        out = renderer.render_template(TEMPLATE, _ctx(1))
+        assert _device_inst_slot(out) == 1
+        assert _impl_for_slot(out, 1) != "pcileech_bar_impl_loopaddr"
+        assert "pcileech_bar_impl_loopaddr" not in out  # slot 1 was its only home
+
+    def test_64bit_served_index_1_makes_partner_slot2_none(self, renderer):
+        out = renderer.render_template(TEMPLATE, _ctx(1, is_64bit=True))
+        assert _device_inst_slot(out) == 1
+        assert _impl_for_slot(out, 2) == "pcileech_bar_impl_none"
+
+    def test_all_seven_slots_present_exactly_once(self, renderer):
+        out = renderer.render_template(TEMPLATE, _ctx(2))
+        for k in range(7):
+            assert len(re.findall(r"rd_req_bar\[" + str(k) + r"\]", out)) == 1

--- a/tests/test_bar_implementation_generation.py
+++ b/tests/test_bar_implementation_generation.py
@@ -209,7 +209,7 @@ class TestBarImplementationGeneration:
         assert result is not None
         assert "module pcileech_tlps128_bar_controller" in result
         assert "pcileech_bar_impl_device" in result
-        assert "Device-Specific BAR Implementation" in result
+        assert "served register window" in result
 
     def test_generate_bar_controller_without_models(
         self, overlay_generator, context_without_bar_models
@@ -222,7 +222,7 @@ class TestBarImplementationGeneration:
         assert result is not None
         assert "module pcileech_tlps128_bar_controller" in result
         assert "pcileech_bar_impl_zerowrite4k" in result
-        assert "Generic BAR Implementation" in result
+        assert "served register window" in result
 
     @pytest.mark.skip(
         reason="Requires full context - integration test needed"

--- a/tests/test_cfgspace_bar_index.py
+++ b/tests/test_cfgspace_bar_index.py
@@ -1,0 +1,70 @@
+"""cfgspace COE renders the served BAR at its donor PCI index (gap C).
+
+Since the firmware serves exactly one register window (the donor's primary MMIO
+BAR at index N) and the IP disables all other BARs, the config-space shadow must
+place that BAR's size encoding at slot N and leave every other BAR slot zeroed —
+not render BARs positionally by list order (the old behavior, which also wrongly
+hardcoded slot 2 as IO).
+"""
+import re
+from copy import deepcopy
+
+from pcileechfwgenerator.device_clone.config_space_manager import BarInfo
+from tests.test_coe_error_injection import (
+    _minimal_base_context,
+    _render_cfgspace_coe,
+)
+
+
+def _bar_dwords(coe: str):
+    """Return the six BAR dwords (0x10-0x27) in slot order."""
+    region = coe.split("Base Address Registers", 1)[1].split("Cardbus CIS", 1)[0]
+    return re.findall(r"^([0-9A-Fa-f]{8}),", region, re.MULTILINE)
+
+
+def _ctx_with_served(index, size, *, is_64bit=False, is_io=False):
+    ctx = deepcopy(_minimal_base_context())
+    bar = BarInfo(
+        index=index,
+        bar_type="io" if is_io else "memory",
+        address=0xF7000000,
+        size=size,
+        prefetchable=False,
+        is_64bit=is_64bit,
+    )
+    ctx["bar_config"] = {
+        "bars": [bar],
+        "primary_bar": 0,  # list position of served BAR within bars
+        "served_bar_index": index,  # donor PCI index N
+        "served_is_64bit": is_64bit,
+    }
+    return ctx
+
+
+class TestCfgspaceBarIndex:
+    def test_served_bar_rendered_at_its_donor_index(self):
+        coe = _render_cfgspace_coe(_ctx_with_served(2, 65536))
+        dwords = _bar_dwords(coe)
+        assert len(dwords) == 6
+        # 64 KiB memory size mask = ~(0x10000-1) = 0xFFFF0000.
+        assert dwords[2].upper() == "FFFF0000"
+        # Every other slot is disabled.
+        for k in (0, 1, 3, 4, 5):
+            assert dwords[k] == "00000000"
+
+    def test_64bit_served_marks_partner_slot_upper_dword(self):
+        coe = _render_cfgspace_coe(
+            _ctx_with_served(2, 2 * 1024 * 1024, is_64bit=True)
+        )
+        dwords = _bar_dwords(coe)
+        # Lower dword at slot 2 carries the 64-bit type bit (0x4).
+        assert int(dwords[2], 16) & 0x4
+        # Slot 3 (partner) is the all-ones upper dword.
+        assert dwords[3].upper() == "FFFFFFFF"
+
+    def test_index_0_back_compat_slot0_carries_encoding(self):
+        coe = _render_cfgspace_coe(_ctx_with_served(0, 4096))
+        dwords = _bar_dwords(coe)
+        assert dwords[0] != "00000000"
+        for k in (1, 2, 3, 4, 5):
+            assert dwords[k] == "00000000"

--- a/tests/test_pcie_ip_donor_override_bar.py
+++ b/tests/test_pcie_ip_donor_override_bar.py
@@ -1,11 +1,11 @@
-"""Tests for donor BAR aperture override (gap A5).
+"""Tests for donor BAR aperture override (gaps A5 + C).
 
 Propagates the served donor BAR's geometry (size/type/64-bit/prefetchable)
-into the Xilinx 7-series PCIe IP via ``CONFIG.Bar0_*`` so PCIe enumeration's
+into the Xilinx 7-series PCIe IP via ``CONFIG.Bar{N}_*`` so PCIe enumeration's
 size probe sees the donor aperture instead of the Xilinx 4 KB default.
 
-The served BAR is always presented as config-space BAR0 (the only window the
-PCILeech BAR controller services via ``i_bar0``), so v1 mirrors a single BAR.
+v1 mirrors a single register BAR, served at its real donor PCI index N (gap C);
+every other BAR index is disabled so the host enumerates exactly one window.
 """
 import sys
 from pathlib import Path

--- a/tests/test_pcie_ip_donor_override_bar.py
+++ b/tests/test_pcie_ip_donor_override_bar.py
@@ -1,0 +1,282 @@
+"""Tests for donor BAR aperture override (gap A5).
+
+Propagates the served donor BAR's geometry (size/type/64-bit/prefetchable)
+into the Xilinx 7-series PCIe IP via ``CONFIG.Bar0_*`` so PCIe enumeration's
+size probe sees the donor aperture instead of the Xilinx 4 KB default.
+
+The served BAR is always presented as config-space BAR0 (the only window the
+PCILeech BAR controller services via ``i_bar0``), so v1 mirrors a single BAR.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).parent.parent.resolve()
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))
+
+from pcileechfwgenerator.vivado_handling.fifo_donor_patcher import DonorIDs
+from pcileechfwgenerator.device_clone.pcileech_context import BarConfiguration
+from pcileechfwgenerator.vivado_handling.pcie_ip_donor_override import (
+    DonorPCIeIPConfig,
+    _bytes_to_xilinx_scale_size,
+    donor_pcie_ip_config_from_result,
+    generate_pcie_ip_override_tcl,
+)
+
+_SCALE_UNITS = {
+    "Bytes": 1,
+    "Kilobytes": 1024,
+    "Megabytes": 1024 * 1024,
+    "Gigabytes": 1024 * 1024 * 1024,
+}
+
+
+def _decode_emitted_bar0_bytes(tcl: str) -> int:
+    """Recover the BAR0 aperture in bytes from the emitted CONFIG lines."""
+    scale = size = None
+    for line in tcl.splitlines():
+        line = line.strip().rstrip("\\").strip()
+        if line.startswith("CONFIG.Bar0_Scale "):
+            scale = line.split()[1]
+        elif line.startswith("CONFIG.Bar0_Size "):
+            size = int(line.split()[1])
+    assert scale is not None and size is not None, tcl
+    return size * _SCALE_UNITS[scale]
+
+
+def _mem_bar(index, size, is_64bit=False, prefetchable=False) -> BarConfiguration:
+    return BarConfiguration(
+        index=index,
+        base_address=0xF0000000,
+        size=size,
+        bar_type=0,
+        prefetchable=prefetchable,
+        is_memory=True,
+        is_io=False,
+        is_64bit=is_64bit,
+    )
+
+
+def _intel_donor() -> DonorIDs:
+    return DonorIDs(
+        vendor_id=0x8086,
+        device_id=0x1533,
+        subsystem_vendor_id=0x8086,
+        subsystem_id=0x0001,
+        revision_id=0x03,
+    )
+
+
+class TestBytesToXilinxScaleSize:
+    """``_bytes_to_xilinx_scale_size`` maps a byte size to the IP's (Scale, Size)."""
+
+    @pytest.mark.parametrize(
+        "size_bytes,expected",
+        [
+            (4 * 1024, ("Kilobytes", 4)),
+            (64 * 1024, ("Kilobytes", 64)),
+            (512 * 1024, ("Kilobytes", 512)),
+            (1 * 1024 * 1024, ("Megabytes", 1)),
+            (2 * 1024 * 1024, ("Megabytes", 2)),
+            (16 * 1024 * 1024, ("Megabytes", 16)),
+            (1 * 1024 * 1024 * 1024, ("Gigabytes", 1)),
+            (2 * 1024 * 1024 * 1024, ("Gigabytes", 2)),
+        ],
+    )
+    def test_canonical_scale_uses_largest_unit(self, size_bytes, expected):
+        # Always pick the largest scale that divides evenly so the multiplier
+        # stays below 1024 (matches the Vivado GUI's Scale/Size split).
+        assert _bytes_to_xilinx_scale_size(size_bytes) == expected
+
+
+class TestBarApertureEmit:
+    """``generate_pcie_ip_override_tcl`` emits ``CONFIG.Bar0_*`` from the aperture."""
+
+    def test_memory_bar_emits_full_bar0_block(self):
+        extra = DonorPCIeIPConfig(
+            bar_aperture_size=64 * 1024,  # 64 KiB
+            bar_is_memory=True,
+            bar_is_64bit=False,
+            bar_prefetchable=False,
+        )
+        tcl = generate_pcie_ip_override_tcl(_intel_donor(), extra=extra)
+        assert "CONFIG.Bar0_Enabled true" in tcl
+        assert "CONFIG.Bar0_Type Memory" in tcl
+        assert "CONFIG.Bar0_64bit false" in tcl
+        assert "CONFIG.Bar0_Prefetchable false" in tcl
+        assert "CONFIG.Bar0_Scale Kilobytes" in tcl
+        assert "CONFIG.Bar0_Size 64" in tcl
+
+    def test_64bit_prefetchable_bar_sets_flags_and_disables_bar1(self):
+        extra = DonorPCIeIPConfig(
+            bar_aperture_size=2 * 1024 * 1024,  # 2 MiB
+            bar_is_memory=True,
+            bar_is_64bit=True,
+            bar_prefetchable=True,
+        )
+        tcl = generate_pcie_ip_override_tcl(_intel_donor(), extra=extra)
+        assert "CONFIG.Bar0_Type Memory" in tcl
+        assert "CONFIG.Bar0_64bit true" in tcl
+        assert "CONFIG.Bar0_Prefetchable true" in tcl
+        assert "CONFIG.Bar0_Scale Megabytes" in tcl
+        assert "CONFIG.Bar0_Size 2" in tcl
+        # A 64-bit BAR consumes the next slot.
+        assert "CONFIG.Bar1_Enabled false" in tcl
+
+    def test_io_bar_forces_no_64bit_no_prefetch(self):
+        extra = DonorPCIeIPConfig(
+            bar_aperture_size=256,
+            bar_is_memory=False,
+            bar_is_64bit=True,  # nonsensical for IO — must be coerced off
+            bar_prefetchable=True,  # ditto
+        )
+        tcl = generate_pcie_ip_override_tcl(_intel_donor(), extra=extra)
+        assert "CONFIG.Bar0_Type IO" in tcl
+        assert "CONFIG.Bar0_64bit false" in tcl
+        assert "CONFIG.Bar0_Prefetchable false" in tcl
+        assert "CONFIG.Bar0_Scale Bytes" in tcl
+        assert "CONFIG.Bar0_Size 256" in tcl
+
+    def test_no_aperture_emits_no_bar_lines(self):
+        tcl = generate_pcie_ip_override_tcl(_intel_donor(), extra=DonorPCIeIPConfig())
+        assert "Bar0_" not in tcl
+
+    def test_served_at_index_2_emits_bar2_and_disables_others(self):
+        extra = DonorPCIeIPConfig(
+            bar_aperture_size=64 * 1024,
+            bar_is_memory=True,
+            bar_index=2,
+        )
+        tcl = generate_pcie_ip_override_tcl(_intel_donor(), extra=extra)
+        assert "CONFIG.Bar2_Enabled true" in tcl
+        assert "CONFIG.Bar2_Type Memory" in tcl
+        assert "CONFIG.Bar2_Scale Kilobytes" in tcl
+        assert "CONFIG.Bar2_Size 64" in tcl
+        # The served index is enabled, never disabled.
+        assert "CONFIG.Bar2_Enabled false" not in tcl
+        # Non-served indices (incl. the .xci default BAR0) are disabled so the
+        # host sees exactly one BAR — no phantom/hanging windows.
+        assert "CONFIG.Bar0_Enabled false" in tcl
+        assert "CONFIG.Bar1_Enabled false" in tcl
+        assert "CONFIG.Bar3_Enabled false" in tcl
+
+    def test_64bit_served_at_index_2_disables_partner_bar3(self):
+        extra = DonorPCIeIPConfig(
+            bar_aperture_size=2 * 1024 * 1024,
+            bar_is_memory=True,
+            bar_is_64bit=True,
+            bar_index=2,
+        )
+        tcl = generate_pcie_ip_override_tcl(_intel_donor(), extra=extra)
+        assert "CONFIG.Bar2_Enabled true" in tcl
+        assert "CONFIG.Bar2_64bit true" in tcl
+        # 64-bit consumes the adjacent slot.
+        assert "CONFIG.Bar3_Enabled false" in tcl
+
+    def test_64bit_at_top_index_rejected(self):
+        # A 64-bit BAR at index 5 would need BAR6 (Expansion ROM) as its upper
+        # half — electrically invalid PCI. Reject loudly rather than emit a
+        # mismatched cfgspace/IP/controller triple.
+        extra = DonorPCIeIPConfig(
+            bar_aperture_size=2 * 1024 * 1024,
+            bar_is_memory=True,
+            bar_is_64bit=True,
+            bar_index=5,
+        )
+        with pytest.raises(ValueError):
+            generate_pcie_ip_override_tcl(_intel_donor(), extra=extra)
+
+    def test_index_0_back_compat_enables_bar0_disables_rest(self):
+        extra = DonorPCIeIPConfig(
+            bar_aperture_size=4 * 1024, bar_is_memory=True, bar_index=0
+        )
+        tcl = generate_pcie_ip_override_tcl(_intel_donor(), extra=extra)
+        assert "CONFIG.Bar0_Enabled true" in tcl
+        assert "CONFIG.Bar0_Enabled false" not in tcl
+        assert "CONFIG.Bar1_Enabled false" in tcl
+
+    def test_sub_4kb_memory_bar_rejected(self):
+        extra = DonorPCIeIPConfig(bar_aperture_size=2048, bar_is_memory=True)
+        with pytest.raises(ValueError):
+            generate_pcie_ip_override_tcl(_intel_donor(), extra=extra)
+
+    def test_non_power_of_two_rejected(self):
+        extra = DonorPCIeIPConfig(bar_aperture_size=48 * 1024, bar_is_memory=True)
+        with pytest.raises(ValueError):
+            generate_pcie_ip_override_tcl(_intel_donor(), extra=extra)
+
+
+class TestBarApertureExtractor:
+    """``donor_pcie_ip_config_from_result`` reads the served BAR from bar_config."""
+
+    def test_extracts_served_bar_geometry(self):
+        result = {
+            "template_context": {
+                "bar_config": {
+                    "bars": [_mem_bar(0, 64 * 1024, is_64bit=True, prefetchable=True)],
+                }
+            }
+        }
+        cfg = donor_pcie_ip_config_from_result(result)
+        assert cfg.bar_aperture_size == 64 * 1024
+        assert cfg.bar_is_memory is True
+        assert cfg.bar_is_64bit is True
+        assert cfg.bar_prefetchable is True
+
+    def test_extractor_reads_served_bar_index(self):
+        result = {
+            "template_context": {
+                "bar_config": {
+                    "served_bar_index": 2,
+                    "primary_bar": 1,
+                    "bars": [_mem_bar(0, 4096), _mem_bar(2, 65536)],
+                }
+            }
+        }
+        cfg = donor_pcie_ip_config_from_result(result)
+        assert cfg.bar_index == 2
+        assert cfg.bar_aperture_size == 65536
+
+    def test_no_bar_config_leaves_aperture_none(self):
+        cfg = donor_pcie_ip_config_from_result({"template_context": {}})
+        assert cfg.bar_aperture_size is None
+
+    def test_sub_4kb_served_memory_bar_is_skipped_not_fatal(self):
+        # Defensive: a sub-4KB served BAR must leave the IP default in place,
+        # never make the emit raise and break the build.
+        result = {
+            "template_context": {"bar_config": {"bars": [_mem_bar(0, 2048)]}}
+        }
+        cfg = donor_pcie_ip_config_from_result(result)
+        assert cfg.bar_aperture_size is None
+        # And the override still renders fine (just no Bar0 block).
+        generate_pcie_ip_override_tcl(_intel_donor(), extra=cfg)
+
+    def test_served_bar_follows_primary_bar_index_like_controller(self):
+        # The controller's BAR_SIZE uses bars[primary_bar|default(0)]; the
+        # extractor must anchor on the same entry so the IP aperture matches.
+        result = {
+            "template_context": {
+                "bar_config": {
+                    "primary_bar": 1,
+                    "bars": [_mem_bar(0, 4 * 1024), _mem_bar(2, 1024 * 1024)],
+                }
+            }
+        }
+        cfg = donor_pcie_ip_config_from_result(result)
+        assert cfg.bar_aperture_size == 1024 * 1024
+
+
+class TestApertureMatchesControllerBarSize:
+    """Invariant: emitted IP aperture == the controller's BAR_SIZE for the donor."""
+
+    @pytest.mark.parametrize("size", [4 * 1024, 64 * 1024, 16 * 1024 * 1024])
+    def test_emitted_bar0_decodes_to_served_size(self, size):
+        served = _mem_bar(0, size)
+        result = {"template_context": {"bar_config": {"bars": [served]}}}
+        cfg = donor_pcie_ip_config_from_result(result)
+        tcl = generate_pcie_ip_override_tcl(_intel_donor(), extra=cfg)
+        # Controller's BAR_SIZE = bars[primary_bar|default(0)].size == served.size
+        assert _decode_emitted_bar0_bytes(tcl) == served.size

--- a/tests/test_pcileech_context.py
+++ b/tests/test_pcileech_context.py
@@ -737,6 +737,52 @@ class TestBARConfiguration:
             assert bar_config["memory_type"] == "memory"
             assert len(bar_config["bars"]) == 2
 
+    def test_bar_config_serves_primary_mmio_bar_at_its_donor_index(
+        self, mock_config, config_space_data, behavior_profile
+    ):
+        """Served BAR = primary (largest) MMIO BAR, identified by its donor index.
+
+        For donor-BAR-index serving (gap C) the metadata must point at the
+        donor's real PCI BAR index N (served_bar_index), not list position 0.
+        When the largest MMIO BAR is donor index 2 (e.g. a NIC with BAR0=IO),
+        served_bar_index must be 2 and aperture_size its size. ``primary_bar``
+        is the list position so ``bars[primary_bar]`` still resolves to it.
+        """
+        builder = PCILeechContextBuilder(device_bdf="0000:03:00.0", config=mock_config)
+        bar_configs = [
+            BarConfiguration(
+                index=0,
+                base_address=0xF7000000,
+                size=4096,  # small MMIO at donor index 0
+                bar_type=0,
+                prefetchable=False,
+                is_memory=True,
+                is_io=False,
+            ),
+            BarConfiguration(
+                index=2,  # donor index 2 (index 1 absent) — the register window
+                base_address=0xF7100000,
+                size=65536,  # largest MMIO → the served BAR
+                bar_type=0,
+                prefetchable=False,
+                is_memory=True,
+                is_io=False,
+            ),
+            None,
+        ]
+        with patch.object(builder, "_get_vfio_bar_info") as mock_get_bar:
+            mock_get_bar.side_effect = bar_configs
+            bar_config = builder._build_bar_config(config_space_data, behavior_profile)
+
+        assert bar_config["served_bar_index"] == 2  # donor PCI BAR index N
+        assert bar_config["bar_index"] == 2
+        assert bar_config["aperture_size"] == 65536
+        assert bar_config["served_is_64bit"] is False
+        # primary_bar is the list position; bars[primary_bar] must be the served BAR
+        served = bar_config["bars"][bar_config["primary_bar"]]
+        assert served.index == bar_config["served_bar_index"]
+        assert served.size == bar_config["aperture_size"]
+
     def test_bar_size_estimation(self, mock_config):
         """Test BAR size estimation for different device types."""
         test_cases = [


### PR DESCRIPTION
## Summary

Improves device-clone fidelity for **issue #613** by serving the donor's primary
register BAR at its **real PCI BAR index**, instead of always assuming BAR0.

Donors whose register window isn't BAR0 (common for NICs — e.g. Realtek
RTL8168 with BAR0=IO, BAR2=MMIO) were previously served on the wrong BAR index,
so the host enumerated a Xilinx-default BAR rather than the donor's. Per **PG054**
the 7-series hard IP routes BAR hits by physical PCI index, so the host sees what
the IP `Bar{N}` config advertises — this PR makes that index match the donor.

### Commits
1. **fix(bar): describe the served BAR in bar_config** — replaces the overloaded,
   never-set `primary_bar` key (which silently defaulted to 0) with explicit
   `served_bar_index` (donor index), `primary_bar` (list position),
   `served_is_64bit`, and a served-BAR `aperture_size`. This makes the IP
   aperture, cfgspace shadow, and controller all agree on one served BAR.
2. **feat(bar): serve donor register BAR at its real PCI index (#613)**
   - IP override emits `CONFIG.Bar{N}_*` (size via Scale/Size, type/64-bit/
     prefetch) and **disables every other BAR** so exactly one window enumerates
     (no phantom/hanging BARs).
   - BAR controller wires the device impl to `wr_bar[N]`/`rd_req_bar[N]` via an
     index-aware loop; the 64-bit partner slot `N+1` is forced to `none`
     (fixes a latent double-drive for a 64-bit BAR0); loopaddr kept at slot 1
     when free; **byte-equivalent wiring when N=0**.
   - cfgspace COE renders the served BAR at slot N with the 64-bit upper dword at
     `N+1`; also fixes the pre-existing hardcoded `slot 2 = IO` bug.
   - Overlay keys the learned-model lookup by `served_bar_index`.

### Scope / limits
- **7-series only** (matches the existing donor-IP override).
- **Single served register BAR** (the primary MMIO). Full multi-BAR reproduction
  and IO-primary handling are deferred follow-ups.
- 64-bit BAR at index 5 is rejected (its upper half would be the Expansion ROM).

### Testing
- TDD throughout; 3 new test files (aperture encode/emit, controller index
  serving, cfgspace index rendering) plus updated context/impl tests.
- Full affected suites green (~990 tests); the only failures in the tree are the
  pre-existing, unrelated `donor-template` / CLI-help e2e tests.
- ⚠️ **Hardware validation pending:** a real Vivado build + `lspci -vv` on a
  non-BAR0 donor (e.g. RTL8168) should confirm the donor BAR geometry enumerates
  and BAR reads are serviced **before merge** — this can't be verified in CI.

Closes #613 (pending hardware validation).
