### PR TITLE
fix: fail build on missing donor IDs instead of silent Xilinx-default firmware (#631)

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -48,6 +48,7 @@ from .device_clone.msix_capability import parse_msix_capability
 from .exceptions import MSIXPreloadError  # noqa: F401 - needed for a unit test
 from .exceptions import (
     ConfigurationError,
+    DeviceConfigError,
     FileOperationError,
     ModuleImportError,
     PCILeechBuildError,
@@ -1858,14 +1859,19 @@ class FirmwareBuilder:
             result.get("template_context", {})
         )
         if donor is None:
-            log_warning_safe(
-                self.logger,
-                "Skipping FIFO donor-ID patch: vendor/device IDs missing "
-                "from template context. Generated firmware will report "
-                "Xilinx defaults (issue #593).",
-                prefix="BUILD",
+            # Real donor identity is mandatory — there is no synthetic-donor
+            # mode. Continuing would emit a bitstream carrying Xilinx default
+            # IDs (the explicit anti-pattern this project forbids) and leave
+            # the upstream undeclared `dpcie.pcie_cfg_*` assigns to crash
+            # synthesis (issue #631). Fail loudly instead.
+            raise DeviceConfigError(
+                "Cannot patch FIFO: donor vendor/device IDs are missing from "
+                "the template context. The build collected no usable donor "
+                "identity, so it would produce firmware with Xilinx default "
+                "IDs. Re-run donor collection (Stage 1) and confirm the "
+                "device's vendor/device IDs were captured before building "
+                "(issues #593, #631)."
             )
-            return
 
         src_dir = self.config.output_dir / "src"
         try:

--- a/tests/test_fifo_donor_patcher.py
+++ b/tests/test_fifo_donor_patcher.py
@@ -547,21 +547,27 @@ class TestBuildWiring:
             if "dpcie.pcie_cfg_subsys_vend_id" in line and "assign" in line:
                 assert line.lstrip().startswith("//")
 
-    def test_skips_silently_without_donor_data(self, tmp_path, caplog):
+    def test_raises_without_donor_data(self, tmp_path):
+        """Missing donor IDs must fail the build, not silently continue.
+
+        Real donor identity is mandatory (no synthetic-donor mode). Continuing
+        would emit a bitstream carrying Xilinx default IDs — the explicit
+        anti-pattern this project forbids — so the build must abort hard.
+        """
+        from pcileechfwgenerator.exceptions import DeviceConfigError
+
         src_dir = tmp_path / "src"
         src_dir.mkdir()
         (src_dir / "pcileech_fifo.sv").write_text(ENIGMAX1_FIFO)
 
         builder = self._make_builder(tmp_path)
-        # Empty template_context → no donor data → no patching, just a warning.
-        with caplog.at_level("WARNING"):
+        # Empty template_context → no donor data → build must abort.
+        with pytest.raises(DeviceConfigError) as exc:
             builder._patch_fifo_with_donor_ids({"template_context": {}})
 
+        assert "donor" in str(exc.value).lower()
+        # The staged FIFO must be left untouched (no partial patch).
         assert (src_dir / "pcileech_fifo.sv").read_text() == ENIGMAX1_FIFO
-        assert any(
-            "issue #593" in rec.message or "donor" in rec.message.lower()
-            for rec in caplog.records
-        )
 
     def test_raises_on_anchor_mismatch(self, tmp_path):
         src_dir = tmp_path / "src"


### PR DESCRIPTION
## Problem

Issue #631: a `pcileech_75t484_x1` build crashes Vivado synthesis with:

```
ERROR [Synth 8-6038] cannot resolve hierarchical name for the item 'pcie_cfg_subsys_vend_id'  ... pcileech_fifo.sv:311
ERROR [Synth 8-525]  part-select width could not be resolved to a constant                    ... pcileech_fifo.sv:311
```

Line 311 is the upstream `assign dpcie.pcie_cfg_subsys_vend_id = _pcie_core_config[0+:16];` (plus four more). The `IfPCIeFifoCore` interface doesn't declare those `pcie_cfg_*` fields — the upstream self-inconsistency #593 added a post-copy patch to comment out.

## Root cause

`FirmwareBuilder._patch_fifo_with_donor_ids` bailed out early — **warning and returning** — when `donor_ids_from_template_context` couldn't find a vendor/device ID. That early return skipped the entire #593 patch (including the comment-out of the broken assigns), so synthesis crashed. In cases where those assigns aren't present, the same path would instead emit a bitstream carrying **Xilinx default IDs** — the placeholder-donor anti-pattern this project explicitly forbids.

## Fix

Real donor identity is mandatory (no synthetic-donor mode). When donor vendor/device IDs are missing/zero, raise `DeviceConfigError` immediately with an actionable message pointing back at Stage 1 donor collection, instead of silently continuing toward a synth crash or a wrong bitstream.

## Test

`tests/test_fifo_donor_patcher.py::TestBuildWiring::test_raises_without_donor_data` — replaces the old `test_skips_silently_without_donor_data`; asserts the build aborts with `DeviceConfigError` and leaves the staged FIFO untouched. Full `test_fifo_donor_patcher.py` (40) + `test_board_source_generation.py` + `test_pcie_ip_donor_override.py` (21) pass.

## Note

This converts the silent failure into a clear error. If a reporter's donor collection legitimately captured IDs but the build still failed, that's a separate Stage-1 question — tracked via the triage ask on #631.

Refs #593, #631
