### PR TITLE
fix: source TemplateRenderError from canonical exceptions module (CodeQL #783)

### DIFF
--- a/src/device_clone/pcileech_generator.py
+++ b/src/device_clone/pcileech_generator.py
@@ -34,6 +34,7 @@ from pcileechfwgenerator.error_utils import extract_root_cause
 from pcileechfwgenerator.exceptions import (
     PCILeechGenerationError,
     PlatformCompatibilityError,
+    TemplateRenderError,
 )
 from pcileechfwgenerator.pci_capability.msix_bar_validator import (
     validate_msix_bar_configuration,
@@ -50,7 +51,6 @@ from pcileechfwgenerator.string_utils import (
 from pcileechfwgenerator.templating import (
     AdvancedSVGenerator,
     TemplateRenderer,
-    TemplateRenderError,
 )
 from pcileechfwgenerator.templating.tcl_builder import format_hex_id
 

--- a/tests/test_pcileech_generator_template_error_import.py
+++ b/tests/test_pcileech_generator_template_error_import.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Regression tests for the ``TemplateRenderError`` import in pcileech_generator.
+
+CodeQL alert #783 (py/useless-except) flagged the ``except TemplateRenderError``
+handler in ``pcileech_generator._generate_systemverilog_modules``. The root cause
+is the import source: ``TemplateRenderError`` was pulled from the
+``pcileechfwgenerator.templating`` package, whose ``__init__`` sets
+``TemplateRenderError = None`` when its optional ``template_renderer`` import
+fails (see ``src/templating/__init__.py``). In that degraded state the handler
+becomes ``except None``, which raises ``TypeError`` at match time and masks the
+real SystemVerilog-generation error.
+
+The fix imports ``TemplateRenderError`` from the canonical
+``pcileechfwgenerator.exceptions`` module, where it is defined unconditionally
+and can never be ``None`` -- while remaining the exact same class object that
+``template_renderer`` raises.
+"""
+
+import importlib
+import sys
+
+import pytest
+
+import pcileechfwgenerator.exceptions as exceptions_mod
+
+PG_MODULE = "pcileechfwgenerator.device_clone.pcileech_generator"
+
+
+def _reload_pcileech_generator():
+    """Import (or re-import) the pcileech_generator module fresh."""
+    sys.modules.pop(PG_MODULE, None)
+    return importlib.import_module(PG_MODULE)
+
+
+def test_template_render_error_is_canonical_exception():
+    """In normal state the handler name is a real, canonical exception class."""
+    pg = importlib.import_module(PG_MODULE)
+
+    assert isinstance(pg.TemplateRenderError, type)
+    assert issubclass(pg.TemplateRenderError, BaseException)
+    # Must be the identical class template_renderer actually raises.
+    assert pg.TemplateRenderError is exceptions_mod.TemplateRenderError
+
+
+def test_template_render_error_survives_templating_fallback(monkeypatch):
+    """Regression for #783: the handler name must stay a valid exception class
+    even when the templating package takes its ImportError fallback and sets
+    ``TemplateRenderError = None``.
+
+    Pre-fix this fails because pcileech_generator sourced the name from the
+    templating package (binding ``None``); post-fix it passes because the name
+    comes from ``pcileechfwgenerator.exceptions``.
+    """
+    templating_pkg = importlib.import_module("pcileechfwgenerator.templating")
+
+    # Reproduce exactly what src/templating/__init__.py does on ImportError.
+    monkeypatch.setattr(templating_pkg, "TemplateRenderError", None, raising=False)
+    # Ensure the module body re-executes its imports under the degraded package.
+    monkeypatch.delitem(sys.modules, PG_MODULE, raising=False)
+
+    pg = _reload_pcileech_generator()
+
+    assert pg.TemplateRenderError is not None, (
+        "pcileech_generator.TemplateRenderError became None when the templating "
+        "package hit its ImportError fallback -- `except TemplateRenderError` "
+        "would raise TypeError at match time (CodeQL #783)."
+    )
+    assert isinstance(pg.TemplateRenderError, type)
+    assert issubclass(pg.TemplateRenderError, BaseException)
+
+    # A real error routed through the handler's class still behaves correctly.
+    with pytest.raises(pg.TemplateRenderError):
+        raise pg.TemplateRenderError("boom")
+
+
+@pytest.fixture(autouse=True)
+def _restore_pcileech_generator():
+    """Guarantee a clean, canonical module is cached for subsequent tests."""
+    yield
+    _reload_pcileech_generator()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes the one **real** correctness bug surfaced during a triage of the GitHub code scanning (CodeQL) findings.

`pcileech_generator.py` imported `TemplateRenderError` from the `pcileechfwgenerator.templating` package, whose `__init__` sets `TemplateRenderError = None` in its `ImportError` fallback (`src/templating/__init__.py:19-22`). If that fallback ever triggers, the handler at `pcileech_generator.py:698` becomes `except None`, which raises `TypeError` at exception-match time and **masks the real SystemVerilog-generation error** (CodeQL alert **#783**, `py/useless-except`).

The fix imports `TemplateRenderError` from `pcileechfwgenerator.exceptions`, where it is defined unconditionally. It is the **same class object** that `template_renderer` actually raises (`template_renderer.py:16` imports it from `exceptions`), so exception matching is unchanged — the name simply can never be `None` again.

## Changes

- `src/device_clone/pcileech_generator.py` — move `TemplateRenderError` from the `templating` import to the `exceptions` import.
- `tests/test_pcileech_generator_template_error_import.py` — regression test that reproduces the templating `ImportError` fallback (`templating.TemplateRenderError = None`) and asserts the handler name stays a valid exception class.

## Verification

- Regression test **fails before** the fix (`TemplateRenderError became None`) and **passes after** — TDD-confirmed.
- All 61 related `pcileech_generator` / `template_renderer` tests pass; no regressions.

## Triage notes (not in this PR)

The remaining critical-level CodeQL alerts were reviewed and determined to be **false positives**, to be dismissed on GitHub rather than code-changed:

- **#1098** `base.py:129` (wrong-arguments) — call arity is satisfied; only a redundant double-format.
- **#252** `attribute_access.py:198` (hash-unhashable) — dominated by an explicit `isinstance(..., Hashable)` guard.
- **#702-705, #1059-1060** `string_utils.py` (shell-command-constructed-from-input) — pure logging/formatting helpers; no output reaches a shell (`safe_format` returns text; no `shell=True`/`os.system`/`os.popen` anywhere).

Separately, two `create_subprocess_shell` sites (`system_status.py`, `build_orchestrator.py`) are a defense-in-depth hardening opportunity to restore the documented argv-only invariant — out of scope here.
